### PR TITLE
Fix nuget version

### DIFF
--- a/src/ByteSync.Client/ByteSync.Client.csproj
+++ b/src/ByteSync.Client/ByteSync.Client.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
     <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.3.0" />
-    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.*" />
+    <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="11.3.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="FastRsyncNet" Version="2.4.3" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.700" />


### PR DESCRIPTION
This pull request includes a minor update to the `ByteSync.Client.csproj` file. The change updates the version of the `Avalonia.Markup.Xaml.Loader` package from `11.*` to `11.3.0` to ensure consistency with other Avalonia package versions.