### PR TITLE
Access to filtering syntax documentation

### DIFF
--- a/src/ByteSync.Client/Assets/Resources/Resources.fr.resx
+++ b/src/ByteSync.Client/Assets/Resources/Resources.fr.resx
@@ -1560,6 +1560,6 @@ Voulez-vous enregistrer ce nouveau Profil de Session avec ce nom ?</value>
 		<value>SYNCHRONISATION</value>
 	</data>
 	<data name="ComparisonResult_Filter_SyntaxDocumentation" xml:space="preserve">
-		<value>Documentation sur la syntaxe</value>
+		<value>Syntaxe de filtrage</value>
 	</data>
 </root>

--- a/src/ByteSync.Client/Assets/Resources/Resources.resx
+++ b/src/ByteSync.Client/Assets/Resources/Resources.resx
@@ -1695,6 +1695,6 @@ Do you want to save this new Session Profile with this name?</value>
     <value>SYNCHRONIZATION</value>
   </data>
   <data name="ComparisonResult_Filter_SyntaxDocumentation" xml:space="preserve">
-    <value>Syntax Documentation</value>
+    <value>Filtering Syntax</value>
   </data>
 </root>

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IWebAccessor.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IWebAccessor.cs
@@ -5,6 +5,8 @@ namespace ByteSync.Interfaces.Controls.Communications;
 public interface IWebAccessor
 {
     Task OpenDocumentationUrl();
+    
+    Task OpenDocumentationUrl(Dictionary<string, string> pathPerLanguage);
 
     Task OpenByteSyncWebSite();
         

--- a/src/ByteSync.Client/Services/Communications/WebAccessor.cs
+++ b/src/ByteSync.Client/Services/Communications/WebAccessor.cs
@@ -16,6 +16,25 @@ class WebAccessor : IWebAccessor
 
     public async Task OpenDocumentationUrl()
     {
+        var url = GetDocumentationUrl();
+
+        await DoOpenUrlAsync(url);
+    }
+
+    public async Task OpenDocumentationUrl(Dictionary<string, string> pathPerLanguage)
+    {
+        var url = GetDocumentationUrl();
+        
+        if (pathPerLanguage.TryGetValue(_localizationService.CurrentCultureDefinition?.Code ?? "en", out var path))
+        {
+            url += path.TrimStart('/');
+        }
+
+        await DoOpenUrlAsync(url);
+    }
+    
+    private string GetDocumentationUrl()
+    {
         var languageCode = "";
 
         if (Equals(_localizationService.CurrentCultureDefinition?.Code, "fr"))
@@ -24,8 +43,7 @@ class WebAccessor : IWebAccessor
         }
 
         var url = $"https://www.bytesyncapp.com/{languageCode}documentation/";
-
-        await DoOpenUrlAsync(url);
+        return url;
     }
 
     public async Task OpenByteSyncWebSite()

--- a/src/ByteSync.Client/ViewModels/Sessions/Comparisons/Results/ComparisonResultViewModel.cs
+++ b/src/ByteSync.Client/ViewModels/Sessions/Comparisons/Results/ComparisonResultViewModel.cs
@@ -350,7 +350,13 @@ public class ComparisonResultViewModel : ActivatableViewModelBase
     
     private async Task OpenSyntaxDocumentation()
     {
-        await _webAccessor.OpenDocumentationUrl();
+        Dictionary<string, string> pathPerLanguage = new()
+        {
+            { "en", "/synchronization/filtering-syntax/" },
+            { "fr", "/synchronisation/syntaxe-de-filtrage/" }
+        };
+        
+        await _webAccessor.OpenDocumentationUrl(pathPerLanguage);
     }
     
     private void OnSessionReset()

--- a/tests/ByteSync.Client.IntegrationTests/Business/Filtering/TestFiltering_TextSearch.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Business/Filtering/TestFiltering_TextSearch.cs
@@ -40,4 +40,26 @@ public class TestFiltering_TextSearch : BaseTestFiltering
         // Assert
         result.Should().Be(expectedResult);
     }
+
+    [Test]
+    [TestCase("test 2025", true)]
+    [TestCase("2025 test", true)]
+    [TestCase("test missing", false)]
+    [TestCase("missing 2025", false)]
+    public void Parse_MultiWordTextSearch_ReturnsCorrectExpression(string filterText, bool expectedResult)
+    {
+        // Arrange
+        var pathIdentity = new PathIdentity(FileSystemTypes.File, "/test2025.txt", "test2025.txt", "/test2025.txt");
+        var comparisonItem = new ComparisonItem(pathIdentity);
+        
+        var mockDataPartIndexer = Container.Resolve<Mock<IDataPartIndexer>>();
+        mockDataPartIndexer.Setup(m => m.GetDataPart(It.IsAny<string>()))
+            .Returns((DataPart)null);
+
+        // Act
+        var result = EvaluateFilterExpression(filterText, comparisonItem);
+
+        // Assert
+        result.Should().Be(expectedResult);
+    }
 }


### PR DESCRIPTION
This pull request introduces updates to localization resources, enhancements to the `WebAccessor` service for handling language-specific documentation paths, and new test cases for filtering functionality. Below is a summary of the most important changes grouped by theme:

### Localization Updates:
* Updated French localization in `Resources.fr.resx` to rename "Documentation sur la syntaxe" to "Syntaxe de filtrage".
* Updated English localization in `Resources.resx` to rename "Syntax Documentation" to "Filtering Syntax".

### `WebAccessor` Enhancements:
* Added a new overloaded method `OpenDocumentationUrl(Dictionary<string, string> pathPerLanguage)` to handle language-specific paths for documentation.
* Refactored the `GetDocumentationUrl` method in `WebAccessor` to return the documentation URL string instead of directly opening it.

### ViewModel Update:
* Modified `ComparisonResultViewModel` to use the new `OpenDocumentationUrl(Dictionary<string, string> pathPerLanguage)` method with predefined paths for English and French filtering syntax documentation.

### Filtering Tests:
* Added a new test method `Parse_MultiWordTextSearch_ReturnsCorrectExpression` to verify multi-word text search functionality in filtering logic.