### PR TITLE
Remove unused field email address

### DIFF
--- a/src/ByteSync.Client/ViewModels/Sessions/Members/SessionMachineViewModel.cs
+++ b/src/ByteSync.Client/ViewModels/Sessions/Members/SessionMachineViewModel.cs
@@ -73,8 +73,7 @@ public class SessionMachineViewModel : ActivatableViewModelBase
         _logger = logger;
 
         SessionMemberInfo = sessionMemberInfo;
-
-        EmailAddress = "";
+        
         IsLocalMachine = sessionMemberInfo.ClientInstanceId.Equals(environmentService.ClientInstanceId);
         JoinedSessionOn = sessionMemberInfo.JoinedSessionOn;
         
@@ -212,9 +211,6 @@ public class SessionMachineViewModel : ActivatableViewModelBase
 
     [Reactive]
     public string MachineDescription { get; set; }
-
-    [Reactive]
-    public string EmailAddress { get; set; }
         
     [Reactive]
     public bool IsLocalMachine { get; set; }

--- a/src/ByteSync.Client/Views/Sessions/Members/SessionMachineView.axaml
+++ b/src/ByteSync.Client/Views/Sessions/Members/SessionMachineView.axaml
@@ -40,9 +40,6 @@
                     <TextBlock Name="MachineDescriptionTextBlock" FontWeight="Bold" Text="{Binding MachineDescription}" Margin="3" />
                     <TextBlock Name="ClientInstanceIdTextBlock" FontStyle="Italic" Text="{Binding ClientInstanceId}" Margin="3"
                                IsVisible="{Binding ClientInstanceId, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                    <!--  Foreground="{StaticResource SystemBaseHighColor}" -->
-                    <TextBlock Name="EmailAddressTextBlock" Text="{Binding EmailAddress}" Margin="3"
-                               Foreground="{StaticResource SystemBaseHighColor}" />
                 </StackPanel>
             </Grid>
 


### PR DESCRIPTION
This PR removes the unused `EmailAddress` property from the session member UI to simplify the codebase:

- **ViewModel Cleanup**  
  - Removed the `EmailAddress` property and its initialization from `SessionMachineViewModel`

- **View Update**  
  - Removed the `EmailAddressTextBlock` element, along with its binding and styling, from `SessionMachineView`