### PR TITLE
Add DataNode and DTO structures

### DIFF
--- a/src/ByteSync.Client/Business/DataNodes/DataNode.cs
+++ b/src/ByteSync.Client/Business/DataNodes/DataNode.cs
@@ -1,0 +1,17 @@
+using ByteSync.Business.DataSources;
+
+namespace ByteSync.Business.DataNodes;
+
+public class DataNode
+{
+    public DataNode()
+    {
+        DataSources = new List<DataSource>();
+    }
+
+    public string NodeId { get; set; } = null!;
+
+    public string ClientInstanceId { get; set; } = null!;
+
+    public List<DataSource> DataSources { get; set; }
+}

--- a/src/ByteSync.Common/Business/Sessions/DataNodeDTO.cs
+++ b/src/ByteSync.Common/Business/Sessions/DataNodeDTO.cs
@@ -1,0 +1,16 @@
+namespace ByteSync.Common.Business.Sessions;
+
+public class DataNodeDTO : BaseSessionDto
+{
+    public DataNodeDTO()
+    {
+    }
+
+    public DataNodeDTO(string sessionId, string clientInstanceId, EncryptedDataNode encryptedDataNode)
+        : base(sessionId, clientInstanceId)
+    {
+        EncryptedDataNode = encryptedDataNode;
+    }
+
+    public EncryptedDataNode EncryptedDataNode { get; set; } = null!;
+}

--- a/src/ByteSync.Common/Business/Sessions/EncryptedDataNode.cs
+++ b/src/ByteSync.Common/Business/Sessions/EncryptedDataNode.cs
@@ -1,0 +1,10 @@
+using ByteSync.Common.Interfaces.Business;
+
+namespace ByteSync.Common.Business.Sessions;
+
+public class EncryptedDataNode : IEncryptedSessionData
+{
+    public byte[] Data { get; set; } = null!;
+
+    public byte[] IV { get; set; } = null!;
+}


### PR DESCRIPTION
## Summary
- introduce `DataNode` model storing node and source info
- support encrypted `DataNode` via `EncryptedDataNode`
- add `DataNodeDTO` for session transfers

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8a28b40883339a9f3ad6aafffe2b