### PR TITLE
[feature] Add data node support

### DIFF
--- a/src/ByteSync.ServerCommon/Business/Sessions/DataNodeData.cs
+++ b/src/ByteSync.ServerCommon/Business/Sessions/DataNodeData.cs
@@ -1,0 +1,16 @@
+using ByteSync.Common.Business.Inventories;
+
+namespace ByteSync.ServerCommon.Business.Sessions;
+
+public class DataNodeData
+{
+    public DataNodeData()
+    {
+        DataSources = new List<EncryptedDataSource>();
+    }
+
+    public string NodeId { get; set; } = null!;
+
+    public List<EncryptedDataSource> DataSources { get; set; }
+}
+

--- a/src/ByteSync.ServerCommon/Business/Sessions/InventoryData.cs
+++ b/src/ByteSync.ServerCommon/Business/Sessions/InventoryData.cs
@@ -22,16 +22,19 @@ public class InventoryData
     {
         foreach (var inventoryMemberData in InventoryMembers)
         {
-            int position = cloudSessionData.SessionMembers.FindIndex(m => m.ClientInstanceId == inventoryMemberData.ClientInstanceId);
-            
-            string letter = ((char)('A' + position)).ToString();
-
-            int cpt = 1;
-            foreach (var dataSource in inventoryMemberData.DataNodes.SelectMany(n => n.DataSources))
+            foreach (var dataNode in inventoryMemberData.DataNodes)
             {
-                dataSource.Code = letter + cpt;
+                int position = cloudSessionData.SessionMembers.FindIndex(m => m.ClientInstanceId == inventoryMemberData.ClientInstanceId);
+            
+                string letter = ((char)('A' + position)).ToString();
 
-                cpt += 1;
+                int cpt = 1;
+                foreach (var dataSource in dataNode.DataSources)
+                {
+                    dataSource.Code = letter + cpt;
+
+                    cpt += 1;
+                }
             }
         }
     }

--- a/src/ByteSync.ServerCommon/Business/Sessions/InventoryData.cs
+++ b/src/ByteSync.ServerCommon/Business/Sessions/InventoryData.cs
@@ -27,7 +27,7 @@ public class InventoryData
             string letter = ((char)('A' + position)).ToString();
 
             int cpt = 1;
-            foreach (var dataSource in inventoryMemberData.SharedDataSources)
+            foreach (var dataSource in inventoryMemberData.DataNodes.SelectMany(n => n.DataSources))
             {
                 dataSource.Code = letter + cpt;
 

--- a/src/ByteSync.ServerCommon/Business/Sessions/InventoryMemberData.cs
+++ b/src/ByteSync.ServerCommon/Business/Sessions/InventoryMemberData.cs
@@ -7,7 +7,7 @@ public class InventoryMemberData
 {
     public InventoryMemberData()
     {
-        SharedDataSources = new List<EncryptedDataSource>();
+        DataNodes = new List<DataNodeData>();
     }
     
     public string SessionId { get; set; } = null!;
@@ -18,5 +18,5 @@ public class InventoryMemberData
         
     public DateTimeOffset? LastLocalInventoryStatusUpdate { get; set; }
     
-    public List<EncryptedDataSource> SharedDataSources { get; set; }
+    public List<DataNodeData> DataNodes { get; set; }
 }

--- a/src/ByteSync.ServerCommon/Commands/CloudSessions/QuitSessionCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/CloudSessions/QuitSessionCommandHandler.cs
@@ -6,6 +6,7 @@ using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
 using ByteSync.ServerCommon.Interfaces.Services.Clients;
 using MediatR;
+using System.Linq;
 
 namespace ByteSync.ServerCommon.Commands.CloudSessions;
 
@@ -67,7 +68,7 @@ public class QuitSessionCommandHandler : IRequestHandler<QuitSessionRequest>
                 var inventoryMember = inventoryData.InventoryMembers.SingleOrDefault(m => m.ClientInstanceId.Equals(request.ClientInstanceId));
                 if (inventoryMember != null)
                 {
-                    dataSources = inventoryMember.SharedDataSources;
+                    dataSources = inventoryMember.DataNodes.SelectMany(n => n.DataSources).ToList();
                     inventoryData.InventoryMembers.Remove(inventoryMember);
                 }
 

--- a/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
@@ -3,6 +3,7 @@ using ByteSync.ServerCommon.Business.Sessions;
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
 using ByteSync.ServerCommon.Interfaces.Services.Clients;
+using System.Linq;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -51,8 +52,15 @@ public class AddDataSourceCommandHandler : IRequestHandler<AddDataSourceRequest,
             {
                 var inventoryMember = _inventoryMemberService.GetOrCreateInventoryMember(inventoryData, sessionId, client);
 
-                inventoryMember.SharedDataSources.RemoveAll(p => p.Code == encryptedDataSource.Code);
-                inventoryMember.SharedDataSources.Add(encryptedDataSource);
+                var dataNode = inventoryMember.DataNodes.FirstOrDefault();
+                if (dataNode == null)
+                {
+                    dataNode = new DataNodeData { NodeId = client.ClientInstanceId };
+                    inventoryMember.DataNodes.Add(dataNode);
+                }
+
+                dataNode.DataSources.RemoveAll(p => p.Code == encryptedDataSource.Code);
+                dataNode.DataSources.Add(encryptedDataSource);
 
                 inventoryData.RecodeDataSources(cloudSessionData);
                 

--- a/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
@@ -52,6 +52,7 @@ public class AddDataSourceCommandHandler : IRequestHandler<AddDataSourceRequest,
             {
                 var inventoryMember = _inventoryMemberService.GetOrCreateInventoryMember(inventoryData, sessionId, client);
 
+                // TODO data-nodes-and-local-sync : to rework
                 var dataNode = inventoryMember.DataNodes.FirstOrDefault();
                 if (dataNode == null)
                 {

--- a/src/ByteSync.ServerCommon/Commands/Inventories/GetDataSourcesCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/GetDataSourcesCommandHandler.cs
@@ -2,6 +2,7 @@
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 
 namespace ByteSync.ServerCommon.Commands.Inventories;
 
@@ -39,6 +40,6 @@ public class GetDataSourcesCommandHandler : IRequestHandler<GetDataSourcesReques
             return new List<EncryptedDataSource>();
         }
 
-        return inventoryMember.SharedDataSources;
+        return inventoryMember.DataNodes.SelectMany(n => n.DataSources).ToList();
     }
 }

--- a/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceCommandHandler.cs
@@ -5,6 +5,7 @@ using ByteSync.ServerCommon.Interfaces.Services;
 using ByteSync.ServerCommon.Interfaces.Services.Clients;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 
 namespace ByteSync.ServerCommon.Commands.Inventories;
 
@@ -47,7 +48,10 @@ public class RemoveDataSourceCommandHandler : IRequestHandler<RemoveDataSourceRe
             {
                 var inventoryMember = _inventoryMemberService.GetOrCreateInventoryMember(inventoryData, request.SessionId, request.Client);
 
-                inventoryMember.SharedDataSources.RemoveAll(p => p.Code == request.EncryptedDataSource.Code);
+                foreach (var node in inventoryMember.DataNodes)
+                {
+                    node.DataSources.RemoveAll(p => p.Code == request.EncryptedDataSource.Code);
+                }
 
                 inventoryData.RecodeDataSources(cloudSessionData);
 

--- a/src/ByteSync.ServerCommon/Commands/Inventories/StartInventoryCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/StartInventoryCommandHandler.cs
@@ -8,6 +8,7 @@ using ByteSync.ServerCommon.Interfaces.Services;
 using ByteSync.ServerCommon.Interfaces.Services.Clients;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using RedLockNet;
 using StackExchange.Redis;
 
@@ -123,7 +124,7 @@ public class StartInventoryCommandHandler : IRequestHandler<StartInventoryReques
                 startInventoryResult = LogAndBuildStartInventoryResult(cloudSessionData, StartInventoryStatuses.UnknownError);
             }
             else if (inventoryData.InventoryMembers.Count < cloudSessionData.SessionMembers.Count
-                     || inventoryData.InventoryMembers.Any(imd => imd.SharedDataSources.Count == 0))
+                     || inventoryData.InventoryMembers.Any(imd => imd.DataNodes.Sum(n => n.DataSources.Count) == 0))
             {
                 startInventoryResult = LogAndBuildStartInventoryResult(cloudSessionData, StartInventoryStatuses.AtLeastOneMemberWithNoDataToSynchronize);
             }

--- a/tests/ByteSync.ServerCommon.Tests/Commands/CloudSessions/QuitSessionCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/CloudSessions/QuitSessionCommandHandlerTests.cs
@@ -242,11 +242,11 @@ public async Task QuitSession_WithDataSources_NotifiesDataSourceRemoved()
 
     // Create inventory data with path items
     var inventoryData = new InventoryData(sessionId);
-    var inventoryMember = new InventoryMemberData { ClientInstanceId = "clientInstance1" };
+    var inventoryMember = new InventoryMemberData { ClientInstanceId = "clientInstance1", DataNodes = [ new DataNodeData { NodeId = "clientInstance1" } ] };
     var dataSource1 = new EncryptedDataSource { Code = "path1", Data = new byte[] { 1, 2, 3 }, IV = new byte[] { 4, 5, 6 } };
     var dataSource2 = new EncryptedDataSource { Code = "path2", Data = new byte[] { 7, 8, 9 }, IV = new byte[] { 10, 11, 12 } };
-    inventoryMember.SharedDataSources.Add(dataSource1);
-    inventoryMember.SharedDataSources.Add(dataSource2);
+    inventoryMember.DataNodes[0].DataSources.Add(dataSource1);
+    inventoryMember.DataNodes[0].DataSources.Add(dataSource2);
     inventoryData.InventoryMembers.Add(inventoryMember);
     
     var synchronizationEntity = new SynchronizationEntity

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataSourceCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataSourceCommandHandlerTests.cs
@@ -8,6 +8,7 @@ using ByteSync.ServerCommon.Commands.Inventories;
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
 using ByteSync.ServerCommon.Interfaces.Services.Clients;
+using System.Linq;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -114,7 +115,7 @@ public class AddDataSourceCommandHandlerTests
         var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = client.ClientInstanceId, SharedDataSources = new List<EncryptedDataSource> { encryptedDataSource } });
+            { ClientInstanceId = client.ClientInstanceId, DataNodes = [ new DataNodeData { NodeId = client.ClientInstanceId, DataSources = new List<EncryptedDataSource> { encryptedDataSource } } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(new CloudSessionData(null, new EncryptedSessionSettings(), client));
@@ -129,7 +130,7 @@ public class AddDataSourceCommandHandlerTests
 
         // Assert
         inventoryData.InventoryMembers.Count.Should().Be(1);
-        inventoryData.InventoryMembers[0].SharedDataSources.Count.Should().Be(1);
+        inventoryData.InventoryMembers[0].DataNodes.Single().DataSources.Count.Should().Be(1);
         A.CallTo(() => _mockInventoryRepository.AddOrUpdate(sessionId, A<Func<InventoryData?, InventoryData?>>.Ignored)).MustHaveHappenedOnceExactly();
     }
 }

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/GetPathItemsCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/GetPathItemsCommandHandlerTests.cs
@@ -37,7 +37,7 @@ public class GetDataSourcesCommandHandlerTests
         var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = client.ClientInstanceId, SharedDataSources = new List<EncryptedDataSource> { encryptedDataSource } });
+            { ClientInstanceId = client.ClientInstanceId, DataNodes = [ new DataNodeData { NodeId = client.ClientInstanceId, DataSources = new List<EncryptedDataSource> { encryptedDataSource } } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(new CloudSessionData(null, new EncryptedSessionSettings(), client));
@@ -84,7 +84,7 @@ public class GetDataSourcesCommandHandlerTests
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
         var dataSource = new EncryptedDataSource { Code = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
-        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId, SharedDataSources = new List<EncryptedDataSource> { dataSource } });
+        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId, DataNodes = [ new DataNodeData { NodeId = client.ClientInstanceId, DataSources = new List<EncryptedDataSource> { dataSource } } ] });
 
         A.CallTo(() => _mockInventoryRepository.Get(sessionId))
             .Returns(inventoryData);

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataSourceCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataSourceCommandHandlerTests.cs
@@ -73,7 +73,7 @@ public class RemoveDataSourceCommandHandlerTests
         var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = client.ClientInstanceId, SharedDataSources = new List<EncryptedDataSource> { encryptedDataSource } });
+            { ClientInstanceId = client.ClientInstanceId, DataNodes = [ new DataNodeData { NodeId = client.ClientInstanceId, DataSources = new List<EncryptedDataSource> { encryptedDataSource } } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(new CloudSessionData(null, new EncryptedSessionSettings(), client));

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/StartInventoryCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/StartInventoryCommandHandlerTests.cs
@@ -178,9 +178,9 @@ public class StartInventoryCommandHandlerTests
             new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" });
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client2", "client2", new PublicKeyInfo(), null, cloudSessionData));
-        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client1", SharedDataSources = [] });
-        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client2", SharedDataSources = [] });
-        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client3", SharedDataSources = [] });
+        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client1", DataNodes = [ new DataNodeData { NodeId = "client1" } ] });
+        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client2", DataNodes = [ new DataNodeData { NodeId = "client2" } ] });
+        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client3", DataNodes = [ new DataNodeData { NodeId = "client3" } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.UpdateIfExists(A<string>.Ignored, A<Func<CloudSessionData, bool>>.Ignored, A<ITransaction>.Ignored, A<IRedLock>.Ignored))
             .Invokes((string _, Func<CloudSessionData, bool> func, ITransaction _, IRedLock _) => func(cloudSessionData))
@@ -215,8 +215,8 @@ public class StartInventoryCommandHandlerTests
             new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" });
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client2", "client2", new PublicKeyInfo(), null, cloudSessionData));
-        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client1", SharedDataSources = [encryptedDataSource] });
-        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client2", SharedDataSources = [] });
+        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client1", DataNodes = [ new DataNodeData { NodeId = "client1", DataSources = [encryptedDataSource] } ] });
+        inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = "client2", DataNodes = [ new DataNodeData { NodeId = "client2" } ] });
         
         A.CallTo(() => _mockCloudSessionsRepository.UpdateIfExists(A<string>.Ignored, A<Func<CloudSessionData, bool>>.Ignored, A<ITransaction>.Ignored, A<IRedLock>.Ignored))
             .Invokes((string _, Func<CloudSessionData, bool> func, ITransaction _, IRedLock _) => func(cloudSessionData))
@@ -251,9 +251,9 @@ public class StartInventoryCommandHandlerTests
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client2", "client2", new PublicKeyInfo(), null, cloudSessionData));
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client1", SharedDataSources = [new() { Code = "dataSource1" }] });
+            { ClientInstanceId = "client1", DataNodes = [ new DataNodeData { NodeId = "client1", DataSources = [new() { Code = "dataSource1" }] } ] });
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client2", SharedDataSources = [new() { Code = "dataSource2" }] });
+            { ClientInstanceId = "client2", DataNodes = [ new DataNodeData { NodeId = "client2", DataSources = [new() { Code = "dataSource2" }] } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(cloudSessionData);
@@ -325,7 +325,7 @@ public class StartInventoryCommandHandlerTests
             new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" });
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client1", SharedDataSources = [new() { Code = "dataSource1" }] });
+            { ClientInstanceId = "client1", DataNodes = [ new DataNodeData { NodeId = "client1", DataSources = [new() { Code = "dataSource1" }] } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(cloudSessionData);
@@ -362,9 +362,9 @@ public class StartInventoryCommandHandlerTests
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client2", "client2", new PublicKeyInfo(), null, cloudSessionData));
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client1", SharedDataSources = [new() { Code = "dataSource1" }] });
+            { ClientInstanceId = "client1", DataNodes = [ new DataNodeData { NodeId = "client1", DataSources = [new() { Code = "dataSource1" }] } ] });
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client2", SharedDataSources = [new() { Code = "dataSource2" }] });
+            { ClientInstanceId = "client2", DataNodes = [ new DataNodeData { NodeId = "client2", DataSources = [new() { Code = "dataSource2" }] } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(cloudSessionData);


### PR DESCRIPTION
## Summary
- introduce `DataNodeData` to represent node data sources
- adapt inventory member data to use data nodes
- update data source recoding to traverse nodes
- refactor commands and tests for new structure

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8cb377a083339c91712bec945c53