### PR TITLE
[feature] add DataNode push support

### DIFF
--- a/src/ByteSync.Client/Interfaces/Controls/Communications/SignalR/IHubPushHandler2.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/SignalR/IHubPushHandler2.cs
@@ -18,6 +18,8 @@ public interface IHubPushHandler2
     Subject<SessionSettingsUpdatedDTO> SessionSettingsUpdated { get; }
     Subject<CloudSessionFatalError> SessionOnFatalError { get; }
     Subject<InventoryStartedDTO> InventoryStarted { get; }
+    Subject<DataNodeDTO> DataNodeAdded { get; }
+    Subject<DataNodeDTO> DataNodeRemoved { get; }
     Subject<DataSourceDTO> DataSourceAdded { get; }
     Subject<DataSourceDTO> DataSourceRemoved { get; }
     Subject<FileTransferPush> FilePartUploaded { get; }

--- a/src/ByteSync.Client/Interfaces/Controls/Encryptions/IDataEncrypter.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Encryptions/IDataEncrypter.cs
@@ -1,6 +1,7 @@
 ﻿using ByteSync.Business.DataSources;
 using ByteSync.Business.SessionMembers;
 using ByteSync.Business.Sessions;
+using ByteSync.Business.DataNodes;
 using ByteSync.Common.Business.Inventories;
 using ByteSync.Common.Business.Sessions;
 
@@ -13,8 +14,12 @@ public interface IDataEncrypter
     public SessionSettings DecryptSessionSettings(EncryptedSessionSettings encryptedSessionSettings);
     
     public EncryptedDataSource EncryptDataSource(DataSource dataSource);
-    
+
     public DataSource DecryptDataSource(EncryptedDataSource encryptedDataSource);
+
+    public EncryptedDataNode EncryptDataNode(DataNode dataNode);
+
+    public DataNode DecryptDataNode(EncryptedDataNode encryptedDataNode);
     
     public EncryptedSessionMemberPrivateData EncryptSessionMemberPrivateData(SessionMemberPrivateData sessionMemberPrivateData);
     

--- a/src/ByteSync.Client/Services/Communications/PushReceivers/DataNodePushReceiver.cs
+++ b/src/ByteSync.Client/Services/Communications/PushReceivers/DataNodePushReceiver.cs
@@ -1,0 +1,45 @@
+using System.Reactive.Linq;
+using ByteSync.Business.DataNodes;
+using ByteSync.Interfaces.Communications;
+using ByteSync.Interfaces.Controls.Communications.SignalR;
+using ByteSync.Interfaces.Controls.Encryptions;
+using ByteSync.Interfaces.Controls.Inventories;
+using ByteSync.Interfaces.Services.Sessions;
+
+namespace ByteSync.Services.Communications.PushReceivers;
+
+public class DataNodePushReceiver : IPushReceiver
+{
+    private readonly ISessionService _sessionService;
+    private readonly IDataEncrypter _dataEncrypter;
+    private readonly IHubPushHandler2 _hubPushHandler2;
+    private readonly IDataNodeService _dataNodeService;
+
+    public DataNodePushReceiver(ISessionService sessionService, IDataEncrypter dataEncrypter,
+        IHubPushHandler2 hubPushHandler2, IDataNodeService dataNodeService)
+    {
+        _sessionService = sessionService;
+        _dataEncrypter = dataEncrypter;
+        _hubPushHandler2 = hubPushHandler2;
+        _dataNodeService = dataNodeService;
+
+        _hubPushHandler2.DataNodeAdded
+            .Where(dto => _sessionService.CheckSession(dto.SessionId))
+            .Subscribe(dto =>
+            {
+                var dataNode = _dataEncrypter.DecryptDataNode(dto.EncryptedDataNode);
+                dataNode.ClientInstanceId = dto.ClientInstanceId;
+                _dataNodeService.ApplyAddDataNodeLocally(dataNode);
+            });
+
+        _hubPushHandler2.DataNodeRemoved
+            .Where(dto => _sessionService.CheckSession(dto.SessionId))
+            .Subscribe(dto =>
+            {
+                var dataNode = _dataEncrypter.DecryptDataNode(dto.EncryptedDataNode);
+                dataNode.ClientInstanceId = dto.ClientInstanceId;
+                _dataNodeService.ApplyRemoveDataNodeLocally(dataNode);
+            });
+    }
+}
+

--- a/src/ByteSync.Client/Services/Communications/SignalR/HubPushHandler2.cs
+++ b/src/ByteSync.Client/Services/Communications/SignalR/HubPushHandler2.cs
@@ -48,6 +48,8 @@ public class HubPushHandler2 : IHubPushHandler2
         new SubjectInfo<SessionSettingsUpdatedDTO>(nameof(IHubByteSyncPush.SessionSettingsUpdated)),
         new SubjectInfo<CloudSessionFatalError>(nameof(IHubByteSyncPush.SessionOnFatalError)),
         new SubjectInfo<InventoryStartedDTO>(nameof(IHubByteSyncPush.InventoryStarted)),
+        new SubjectInfo<DataNodeDTO>(nameof(IHubByteSyncPush.DataNodeAdded)),
+        new SubjectInfo<DataNodeDTO>(nameof(IHubByteSyncPush.DataNodeRemoved)),
         new SubjectInfo<DataSourceDTO>(nameof(IHubByteSyncPush.DataSourceAdded)),
         new SubjectInfo<DataSourceDTO>(nameof(IHubByteSyncPush.DataSourceRemoved)),
         new SubjectInfo<FileTransferPush>(nameof(IHubByteSyncPush.FilePartUploaded)),
@@ -91,10 +93,16 @@ public class HubPushHandler2 : IHubPushHandler2
     public Subject<CloudSessionFatalError> SessionOnFatalError => 
         GetSubject<CloudSessionFatalError>(nameof(IHubByteSyncPush.SessionOnFatalError));
     
-    public Subject<InventoryStartedDTO> InventoryStarted => 
+    public Subject<InventoryStartedDTO> InventoryStarted =>
         GetSubject<InventoryStartedDTO>(nameof(IHubByteSyncPush.InventoryStarted));
-    
-    public Subject<DataSourceDTO> DataSourceAdded => 
+
+    public Subject<DataNodeDTO> DataNodeAdded =>
+        GetSubject<DataNodeDTO>(nameof(IHubByteSyncPush.DataNodeAdded));
+
+    public Subject<DataNodeDTO> DataNodeRemoved =>
+        GetSubject<DataNodeDTO>(nameof(IHubByteSyncPush.DataNodeRemoved));
+
+    public Subject<DataSourceDTO> DataSourceAdded =>
         GetSubject<DataSourceDTO>(nameof(IHubByteSyncPush.DataSourceAdded));
     
     public Subject<DataSourceDTO> DataSourceRemoved => 

--- a/src/ByteSync.Client/Services/Encryptions/DataEncrypter.cs
+++ b/src/ByteSync.Client/Services/Encryptions/DataEncrypter.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using ByteSync.Business.DataSources;
 using ByteSync.Business.SessionMembers;
 using ByteSync.Business.Sessions;
+using ByteSync.Business.DataNodes;
 using ByteSync.Common.Business.Inventories;
 using ByteSync.Common.Business.Sessions;
 using ByteSync.Common.Controls.Json;
@@ -35,8 +36,13 @@ public class DataEncrypter : IDataEncrypter
     {
         var encryptedDataSource = Encrypt<EncryptedDataSource>(dataSource);
         encryptedDataSource.Code = dataSource.Code;
-        
+
         return encryptedDataSource;
+    }
+
+    public EncryptedDataNode EncryptDataNode(DataNode dataNode)
+    {
+        return Encrypt<EncryptedDataNode>(dataNode);
     }
 
     public DataSource DecryptDataSource(EncryptedDataSource encryptedDataSource)
@@ -45,6 +51,11 @@ public class DataEncrypter : IDataEncrypter
         dataSource.Code = encryptedDataSource.Code;
 
         return dataSource;
+    }
+
+    public DataNode DecryptDataNode(EncryptedDataNode encryptedDataNode)
+    {
+        return Decrypt<DataNode>(encryptedDataNode);
     }
     
     public EncryptedSessionMemberPrivateData EncryptSessionMemberPrivateData(SessionMemberPrivateData sessionMemberPrivateData)

--- a/src/ByteSync.Common/Interfaces/Hub/IHubByteSyncPush.cs
+++ b/src/ByteSync.Common/Interfaces/Hub/IHubByteSyncPush.cs
@@ -37,6 +37,10 @@ public interface IHubByteSyncPush
 
     Task InventoryStarted(InventoryStartedDTO inventoryStartedDto);
 
+    Task DataNodeAdded(DataNodeDTO dataNodeDto);
+
+    Task DataNodeRemoved(DataNodeDTO dataNodeDto);
+
     Task DataSourceAdded(DataSourceDTO dataSourceDto);
 
     Task DataSourceRemoved(DataSourceDTO dataSourceDto);


### PR DESCRIPTION
## Summary
- extend hub push interface to handle DataNode events
- wire DataNode events in HubPushHandler2 and add push receiver
- expose DataNode encryption helpers

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eba34ed70833380c69a6230eedfb3