### PR TITLE
[feature] Add data node code generator

### DIFF
--- a/src/ByteSync.Client/Interfaces/Controls/Inventories/IDataNodeCodeGenerator.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Inventories/IDataNodeCodeGenerator.cs
@@ -1,0 +1,8 @@
+using ByteSync.Business.DataNodes;
+
+namespace ByteSync.Interfaces.Controls.Inventories;
+
+public interface IDataNodeCodeGenerator
+{
+    void RecomputeCodes();
+}

--- a/src/ByteSync.Client/Services/Inventories/DataNodeCodeGenerator.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataNodeCodeGenerator.cs
@@ -1,0 +1,87 @@
+using ByteSync.Business.DataNodes;
+using ByteSync.Business.SessionMembers;
+using ByteSync.Interfaces.Controls.Inventories;
+using ByteSync.Interfaces.Repositories;
+using DynamicData;
+
+namespace ByteSync.Services.Inventories;
+
+public class DataNodeCodeGenerator : IDataNodeCodeGenerator, IDisposable
+{
+    private readonly IDataNodeRepository _dataNodeRepository;
+    private readonly ISessionMemberRepository _sessionMemberRepository;
+    private readonly IDisposable _subscription;
+
+    public DataNodeCodeGenerator(IDataNodeRepository dataNodeRepository, ISessionMemberRepository sessionMemberRepository)
+    {
+        _dataNodeRepository = dataNodeRepository;
+        _sessionMemberRepository = sessionMemberRepository;
+
+        _subscription = _dataNodeRepository.ObservableCache.Connect()
+            .WhereReasonsAre(ChangeReason.Add, ChangeReason.Remove)
+            .Subscribe(_ => RecomputeCodes());
+    }
+
+    public void RecomputeCodes()
+    {
+        var allNodes = _dataNodeRepository.Elements.ToList();
+        if (allNodes.Count == 0)
+        {
+            return;
+        }
+
+        var nodesByMember = allNodes
+            .GroupBy(n => n.ClientInstanceId)
+            .ToDictionary(g => g.Key, g => g.OrderBy(n => n.NodeId).ToList());
+
+        bool singlePerMember = nodesByMember.Values.All(list => list.Count == 1);
+
+        var sessionMembers = _sessionMemberRepository.SortedSessionMembers.ToList();
+        var updates = new List<DataNode>();
+
+        for (int mIndex = 0; mIndex < sessionMembers.Count; mIndex++)
+        {
+            var member = sessionMembers[mIndex];
+            if (!nodesByMember.TryGetValue(member.ClientInstanceId, out var nodes))
+            {
+                continue;
+            }
+
+            var memberLetter = ((char)('A' + mIndex)).ToString();
+
+            if (singlePerMember)
+            {
+                foreach (var node in nodes)
+                {
+                    if (node.Code != memberLetter)
+                    {
+                        node.Code = memberLetter;
+                        updates.Add(node);
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < nodes.Count; i++)
+                {
+                    var code = memberLetter + ((char)('a' + i));
+                    if (nodes[i].Code != code)
+                    {
+                        nodes[i].Code = code;
+                        updates.Add(nodes[i]);
+                    }
+                }
+            }
+        }
+
+        if (updates.Count > 0)
+        {
+            _dataNodeRepository.AddOrUpdate(updates);
+        }
+    }
+
+    public void Dispose()
+    {
+        _subscription.Dispose();
+    }
+}

--- a/src/ByteSync.Client/Services/Inventories/DataNodeService.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataNodeService.cs
@@ -14,14 +14,17 @@ public class DataNodeService : IDataNodeService
     private readonly IConnectionService _connectionService;
     private readonly IInventoryApiClient _inventoryApiClient;
     private readonly IDataNodeRepository _dataNodeRepository;
+    private readonly IDataNodeCodeGenerator _codeGenerator;
 
     public DataNodeService(ISessionService sessionService, IConnectionService connectionService,
-        IInventoryApiClient inventoryApiClient, IDataNodeRepository dataNodeRepository)
+        IInventoryApiClient inventoryApiClient, IDataNodeRepository dataNodeRepository,
+        IDataNodeCodeGenerator codeGenerator)
     {
         _sessionService = sessionService;
         _connectionService = connectionService;
         _inventoryApiClient = inventoryApiClient;
         _dataNodeRepository = dataNodeRepository;
+        _codeGenerator = codeGenerator;
     }
 
     public async Task<bool> TryAddDataNode(DataNode dataNode)
@@ -72,10 +75,12 @@ public class DataNodeService : IDataNodeService
     public void ApplyAddDataNodeLocally(DataNode dataNode)
     {
         _dataNodeRepository.AddOrUpdate(dataNode);
+        _codeGenerator.RecomputeCodes();
     }
 
     public void ApplyRemoveDataNodeLocally(DataNode dataNode)
     {
         _dataNodeRepository.Remove(dataNode);
+        _codeGenerator.RecomputeCodes();
     }
 }

--- a/tests/ByteSync.Client.Tests/Services/Inventories/DataNodeCodeGeneratorTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Inventories/DataNodeCodeGeneratorTests.cs
@@ -1,0 +1,83 @@
+using ByteSync.Business.DataNodes;
+using ByteSync.Business.SessionMembers;
+using ByteSync.Interfaces.Controls.Applications;
+using ByteSync.Interfaces.Controls.Inventories;
+using ByteSync.Interfaces.Repositories;
+using ByteSync.Interfaces.Services.Communications;
+using ByteSync.Repositories;
+using ByteSync.Services.Inventories;
+using ByteSync.Tests.TestUtilities.Helpers;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace ByteSync.Tests.Services.Inventories;
+
+[TestFixture]
+public class DataNodeCodeGeneratorTests
+{
+    private DataNodeRepository _dataNodeRepository = null!;
+    private SessionMemberRepository _sessionMemberRepository = null!;
+    private DataNodeCodeGenerator _generator = null!;
+
+    private Mock<IEnvironmentService> _envMock = null!;
+    private Mock<ISessionInvalidationCachePolicy<DataNode, string>> _nodePolicyMock = null!;
+    private Mock<IConnectionService> _connMock = null!;
+    private Mock<ISessionInvalidationCachePolicy<SessionMember, string>> _memberPolicyMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _envMock = new Mock<IEnvironmentService>();
+        _envMock.SetupGet(e => e.ClientInstanceId).Returns("CID0");
+        _nodePolicyMock = new Mock<ISessionInvalidationCachePolicy<DataNode, string>>();
+
+        _connMock = new Mock<IConnectionService>();
+        _connMock.SetupGet(c => c.ClientInstanceId).Returns("CID0");
+        _memberPolicyMock = new Mock<ISessionInvalidationCachePolicy<SessionMember, string>>();
+
+        _dataNodeRepository = new DataNodeRepository(_envMock.Object, _nodePolicyMock.Object);
+        _sessionMemberRepository = new SessionMemberRepository(_connMock.Object, _memberPolicyMock.Object);
+
+        _generator = new DataNodeCodeGenerator(_dataNodeRepository, _sessionMemberRepository);
+    }
+
+    [Test]
+    public void Codes_AreLetters_WhenSingleNodePerMember()
+    {
+        var member1 = new SessionMember { Endpoint = ByteSyncEndPointHelper.BuildEndPoint("CID0"), JoinedSessionOn = DateTimeOffset.Now.AddSeconds(-10) };
+        var member2 = new SessionMember { Endpoint = ByteSyncEndPointHelper.BuildEndPoint("CID1"), JoinedSessionOn = DateTimeOffset.Now };
+        _sessionMemberRepository.AddOrUpdate(new[] { member1, member2 });
+
+        var node1 = new DataNode { NodeId = "N1", ClientInstanceId = "CID0" };
+        var node2 = new DataNode { NodeId = "N2", ClientInstanceId = "CID1" };
+        _dataNodeRepository.AddOrUpdate(new[] { node1, node2 });
+
+        node1.Code.Should().Be("A");
+        node2.Code.Should().Be("B");
+    }
+
+    [Test]
+    public void Codes_Update_OnNodeAddAndRemove()
+    {
+        var member1 = new SessionMember { Endpoint = ByteSyncEndPointHelper.BuildEndPoint("CID0"), JoinedSessionOn = DateTimeOffset.Now.AddSeconds(-10) };
+        var member2 = new SessionMember { Endpoint = ByteSyncEndPointHelper.BuildEndPoint("CID1"), JoinedSessionOn = DateTimeOffset.Now };
+        _sessionMemberRepository.AddOrUpdate(new[] { member1, member2 });
+
+        var node1 = new DataNode { NodeId = "N1", ClientInstanceId = "CID0" };
+        var node2 = new DataNode { NodeId = "N2", ClientInstanceId = "CID1" };
+        _dataNodeRepository.AddOrUpdate(new[] { node1, node2 });
+
+        var extra = new DataNode { NodeId = "N3", ClientInstanceId = "CID0" };
+        _dataNodeRepository.AddOrUpdate(extra);
+
+        node1.Code.Should().Be("Aa");
+        extra.Code.Should().Be("Ab");
+        node2.Code.Should().Be("Ba");
+
+        _dataNodeRepository.Remove(extra);
+
+        node1.Code.Should().Be("A");
+        node2.Code.Should().Be("B");
+    }
+}

--- a/tests/ByteSync.Client.Tests/Services/Inventories/DataNodeServiceTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Inventories/DataNodeServiceTests.cs
@@ -4,6 +4,7 @@ using ByteSync.Interfaces.Controls.Communications.Http;
 using ByteSync.Interfaces.Repositories;
 using ByteSync.Interfaces.Services.Communications;
 using ByteSync.Interfaces.Services.Sessions;
+using ByteSync.Interfaces.Controls.Inventories;
 using ByteSync.Services.Inventories;
 using FluentAssertions;
 using Moq;
@@ -18,6 +19,7 @@ public class DataNodeServiceTests
     private Mock<IConnectionService> _connectionServiceMock = null!;
     private Mock<IInventoryApiClient> _inventoryApiClientMock = null!;
     private Mock<IDataNodeRepository> _dataNodeRepositoryMock = null!;
+    private Mock<IDataNodeCodeGenerator> _codeGeneratorMock = null!;
     private DataNodeService _service = null!;
 
     [SetUp]
@@ -27,11 +29,13 @@ public class DataNodeServiceTests
         _connectionServiceMock = new Mock<IConnectionService>();
         _inventoryApiClientMock = new Mock<IInventoryApiClient>();
         _dataNodeRepositoryMock = new Mock<IDataNodeRepository>();
+        _codeGeneratorMock = new Mock<IDataNodeCodeGenerator>();
 
         _service = new DataNodeService(_sessionServiceMock.Object,
             _connectionServiceMock.Object,
             _inventoryApiClientMock.Object,
-            _dataNodeRepositoryMock.Object);
+            _dataNodeRepositoryMock.Object,
+            _codeGeneratorMock.Object);
     }
 
     [Test]
@@ -50,6 +54,7 @@ public class DataNodeServiceTests
         result.Should().BeTrue();
         _inventoryApiClientMock.Verify(a => a.AddDataNode(sessionId, node.NodeId), Times.Once);
         _dataNodeRepositoryMock.Verify(r => r.AddOrUpdate(node), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
     }
 
     [Test]
@@ -66,6 +71,7 @@ public class DataNodeServiceTests
         result.Should().BeTrue();
         _inventoryApiClientMock.Verify(a => a.AddDataNode(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         _dataNodeRepositoryMock.Verify(r => r.AddOrUpdate(node), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
     }
 
     [Test]
@@ -83,6 +89,7 @@ public class DataNodeServiceTests
 
         result.Should().BeFalse();
         _dataNodeRepositoryMock.Verify(r => r.AddOrUpdate(It.IsAny<DataNode>()), Times.Never);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Never);
     }
 
     [Test]
@@ -101,6 +108,7 @@ public class DataNodeServiceTests
         result.Should().BeTrue();
         _inventoryApiClientMock.Verify(a => a.RemoveDataNode(sessionId, node.NodeId), Times.Once);
         _dataNodeRepositoryMock.Verify(r => r.Remove(node), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
     }
 
     [Test]
@@ -117,6 +125,7 @@ public class DataNodeServiceTests
         result.Should().BeTrue();
         _inventoryApiClientMock.Verify(a => a.RemoveDataNode(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         _dataNodeRepositoryMock.Verify(r => r.Remove(node), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
     }
 
     [Test]
@@ -134,6 +143,7 @@ public class DataNodeServiceTests
 
         result.Should().BeFalse();
         _dataNodeRepositoryMock.Verify(r => r.Remove(It.IsAny<DataNode>()), Times.Never);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Never);
     }
 
     [Test]
@@ -149,5 +159,6 @@ public class DataNodeServiceTests
         await _service.CreateAndTryAddDataNode("NODE");
 
         _dataNodeRepositoryMock.Verify(r => r.AddOrUpdate(It.Is<DataNode>(n => n.NodeId == "NODE" && n.ClientInstanceId == "CID")), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- create `DataNodeCodeGenerator` to compute `DataNode.Code`
- update `DataNodeService` to trigger the generator
- add interface `IDataNodeCodeGenerator`
- adjust existing unit tests
- add new tests verifying code generation behavior

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `./dotnet-install.sh --version 8.0.100` *(fails: unable to download)*

------
https://chatgpt.com/codex/tasks/task_e_6860db831ef88333a6034662bf7c03e4