### PR TITLE
[feature] implement datasource renumbering

### DIFF
--- a/src/ByteSync.Client/Business/DataSources/DataSource.cs
+++ b/src/ByteSync.Client/Business/DataSources/DataSource.cs
@@ -32,6 +32,8 @@ public class DataSource : ReactiveObject
         }
     }
 
+    public DateTime InitialTimestamp { get; set; }
+
     protected bool Equals(DataSource other)
     {
         return Type == other.Type && Path == other.Path && DataNodeId == other.DataNodeId;

--- a/src/ByteSync.Client/Interfaces/Controls/Inventories/IDataSourceCodeGenerator.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Inventories/IDataSourceCodeGenerator.cs
@@ -1,0 +1,8 @@
+using ByteSync.Business.DataSources;
+
+namespace ByteSync.Interfaces.Controls.Inventories;
+
+public interface IDataSourceCodeGenerator
+{
+    void RecomputeCodesForNode(string dataNodeId);
+}

--- a/src/ByteSync.Client/Services/Inventories/DataSourceCodeGenerator.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataSourceCodeGenerator.cs
@@ -1,0 +1,77 @@
+using ByteSync.Business.DataNodes;
+using ByteSync.Business.DataSources;
+using ByteSync.Interfaces.Controls.Inventories;
+using ByteSync.Interfaces.Repositories;
+using DynamicData;
+
+namespace ByteSync.Services.Inventories;
+
+public class DataSourceCodeGenerator : IDataSourceCodeGenerator, IDisposable
+{
+    private readonly IDataSourceRepository _dataSourceRepository;
+    private readonly IDataNodeRepository _dataNodeRepository;
+    private readonly IDisposable _dataSourceSub;
+    private readonly IDisposable _dataNodeSub;
+
+    public DataSourceCodeGenerator(IDataSourceRepository dataSourceRepository, IDataNodeRepository dataNodeRepository)
+    {
+        _dataSourceRepository = dataSourceRepository;
+        _dataNodeRepository = dataNodeRepository;
+
+        _dataSourceSub = _dataSourceRepository.ObservableCache.Connect()
+            .WhereReasonsAre(ChangeReason.Add, ChangeReason.Remove)
+            .Subscribe(changes =>
+            {
+                foreach (var change in changes)
+                {
+                    RecomputeCodesForNode(change.Current.DataNodeId);
+                }
+            });
+
+        _dataNodeSub = _dataNodeRepository.ObservableCache.Connect()
+            .WhereReasonsAre(ChangeReason.Update)
+            .Subscribe(changes =>
+            {
+                foreach (var change in changes)
+                {
+                    RecomputeCodesForNode(change.Current.NodeId);
+                }
+            });
+    }
+
+    public void RecomputeCodesForNode(string dataNodeId)
+    {
+        var node = _dataNodeRepository.GetElement(dataNodeId);
+        if (node == null)
+        {
+            return;
+        }
+
+        var sources = _dataSourceRepository.Elements
+            .Where(ds => ds.DataNodeId == dataNodeId)
+            .OrderBy(ds => ds.Code)
+            .ToList();
+
+        var updates = new List<DataSource>();
+        for (int i = 0; i < sources.Count; i++)
+        {
+            var newCode = $"{node.Code}{i + 1}";
+            if (sources[i].Code != newCode)
+            {
+                sources[i].Code = newCode;
+                updates.Add(sources[i]);
+            }
+        }
+
+        if (updates.Count > 0)
+        {
+            _dataSourceRepository.AddOrUpdate(updates);
+        }
+    }
+
+    public void Dispose()
+    {
+        _dataSourceSub.Dispose();
+        _dataNodeSub.Dispose();
+    }
+}

--- a/src/ByteSync.Client/Services/Inventories/DataSourceCodeGenerator.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataSourceCodeGenerator.cs
@@ -49,7 +49,7 @@ public class DataSourceCodeGenerator : IDataSourceCodeGenerator, IDisposable
 
         var sources = _dataSourceRepository.Elements
             .Where(ds => ds.DataNodeId == dataNodeId)
-            .OrderBy(ds => ds.Code)
+            .OrderBy(ds => ds.InitialTimestamp)
             .ToList();
 
         var updates = new List<DataSource>();

--- a/src/ByteSync.Client/Services/Inventories/DataSourceService.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataSourceService.cs
@@ -108,6 +108,7 @@ public class DataSourceService : IDataSourceService
         dataSource.Type = fileSystemType;
         dataSource.ClientInstanceId = _connectionService.ClientInstanceId!;
         dataSource.DataNodeId = dataNode.NodeId;
+        dataSource.InitialTimestamp = DateTime.UtcNow;
 
         // var sessionMemberInfo = _dataNodeRepository.GetCurrentSessionMember();
         // dataSource.Code = sessionMemberInfo.GetLetter() +

--- a/src/ByteSync.Client/Services/Inventories/DataSourceService.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataSourceService.cs
@@ -25,10 +25,12 @@ public class DataSourceService : IDataSourceService
     private readonly IInventoryApiClient _inventoryApiClient;
     private readonly IDataSourceRepository _dataSourceRepository;
     private readonly IDataNodeRepository _dataNodeRepository;
+    private readonly IDataSourceCodeGenerator _codeGenerator;
 
     public DataSourceService(ISessionService sessionService, IDataSourceChecker dataSourceChecker, IDataEncrypter dataEncrypter,
         IConnectionService connectionService, IInventoryApiClient inventoryApiClient,
-        IDataSourceRepository dataSourceRepository, IDataNodeRepository dataNodeRepository)
+        IDataSourceRepository dataSourceRepository, IDataNodeRepository dataNodeRepository,
+        IDataSourceCodeGenerator codeGenerator)
     {
         _sessionService = sessionService;
         _dataSourceChecker = dataSourceChecker;
@@ -37,6 +39,7 @@ public class DataSourceService : IDataSourceService
         _inventoryApiClient = inventoryApiClient;
         _dataSourceRepository = dataSourceRepository;
         _dataNodeRepository = dataNodeRepository;
+        _codeGenerator = codeGenerator;
 
         // _dataNodeRepository.SortedSessionMembersObservable
         //     .OnItemRemoved(_ =>
@@ -94,6 +97,7 @@ public class DataSourceService : IDataSourceService
     public void ApplyAddDataSourceLocally(DataSource dataSource)
     {
         _dataSourceRepository.AddOrUpdate(dataSource);
+        _codeGenerator.RecomputeCodesForNode(dataSource.DataNodeId);
     }
 
     public Task CreateAndTryAddDataSource(string path, FileSystemTypes fileSystemType, DataNode dataNode)
@@ -128,34 +132,7 @@ public class DataSourceService : IDataSourceService
     public void ApplyRemoveDataSourceLocally(DataSource dataSource)
     {
         _dataSourceRepository.Remove(dataSource);
-        
-        // var sessionMemberInfo = _dataNodeRepository.GetElement(dataSource.ClientInstanceId);
-        //
-        // if (sessionMemberInfo != null)
-        // {
-        //     UpdateCodesForMember(sessionMemberInfo);
-        // }
+        _codeGenerator.RecomputeCodesForNode(dataSource.DataNodeId);
     }
 
-    // private void UpdateCodesForAllMembers(IEnumerable<DataNode> allSessionMembersInfos)
-    // {
-    //     foreach (var sessionMemberInfo in allSessionMembersInfos)
-    //     {
-    //         UpdateCodesForMember(sessionMemberInfo);
-    //     }
-    // }
-    //
-    // private void UpdateCodesForMember(SessionMember sessionMember)
-    // {
-    //     var dataSources = _dataSourceRepository.Elements
-    //         .Where(ds => ds.BelongsTo(sessionMember))
-    //         .OrderBy(ds => ds.Code);
-    //
-    //     var i = 1;
-    //     foreach (var remainingDataSource in dataSources)
-    //     {
-    //         remainingDataSource.Code = sessionMember.GetLetter() + i;
-    //         i += 1;
-    //     }
-    // }
 }

--- a/tests/ByteSync.Client.Tests/Services/Inventories/DataSourceCodeGeneratorTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Inventories/DataSourceCodeGeneratorTests.cs
@@ -48,8 +48,8 @@ public class DataSourceCodeGeneratorTests
         var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID0", Code = "A" };
         _dataNodeRepository.AddOrUpdate(node);
 
-        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
-        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0", Path = "path1", InitialTimestamp = DateTime.Now};
+        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0", Path = "path2", InitialTimestamp = DateTime.Now.AddMilliseconds(1) };
 
         _dataSourceRepository.AddOrUpdate(ds1);
         _dataSourceRepository.AddOrUpdate(ds2);
@@ -64,9 +64,9 @@ public class DataSourceCodeGeneratorTests
         var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID0", Code = "A" };
         _dataNodeRepository.AddOrUpdate(node);
 
-        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
-        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
-        var ds3 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0", Path = "path1", InitialTimestamp = DateTime.Now };
+        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0", Path = "path2", InitialTimestamp = DateTime.Now.AddMilliseconds(1) };
+        var ds3 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0", Path = "path3", InitialTimestamp = DateTime.Now.AddMilliseconds(2) };
         _dataSourceRepository.AddOrUpdate(new[] { ds1, ds2, ds3 });
 
         _dataSourceRepository.Remove(ds2);
@@ -81,8 +81,8 @@ public class DataSourceCodeGeneratorTests
         var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID0", Code = "A" };
         _dataNodeRepository.AddOrUpdate(node);
 
-        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
-        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0", Path = "path1", InitialTimestamp = DateTime.Now };
+        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0", Path = "path2", InitialTimestamp = DateTime.Now.AddMilliseconds(1) };
         _dataSourceRepository.AddOrUpdate(new[] { ds1, ds2 });
 
         node.Code = "B";

--- a/tests/ByteSync.Client.Tests/Services/Inventories/DataSourceCodeGeneratorTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Inventories/DataSourceCodeGeneratorTests.cs
@@ -1,0 +1,94 @@
+using ByteSync.Business.DataNodes;
+using ByteSync.Business.DataSources;
+using ByteSync.Interfaces.Controls.Applications;
+using ByteSync.Interfaces.Controls.Inventories;
+using ByteSync.Interfaces.Repositories;
+using ByteSync.Repositories;
+using ByteSync.Services.Inventories;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace ByteSync.Tests.Services.Inventories;
+
+[TestFixture]
+public class DataSourceCodeGeneratorTests
+{
+    private DataSourceRepository _dataSourceRepository = null!;
+    private DataNodeRepository _dataNodeRepository = null!;
+    private DataSourceCodeGenerator _generator = null!;
+
+    private Mock<IEnvironmentService> _envMock = null!;
+    private Mock<ISessionInvalidationCachePolicy<DataSource, string>> _dsPolicyMock = null!;
+    private Mock<ISessionInvalidationCachePolicy<DataNode, string>> _nodePolicyMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _envMock = new Mock<IEnvironmentService>();
+        _envMock.SetupGet(e => e.ClientInstanceId).Returns("CID0");
+        _dsPolicyMock = new Mock<ISessionInvalidationCachePolicy<DataSource, string>>();
+        _nodePolicyMock = new Mock<ISessionInvalidationCachePolicy<DataNode, string>>();
+
+        _dataSourceRepository = new DataSourceRepository(_envMock.Object, _dsPolicyMock.Object);
+        _dataNodeRepository = new DataNodeRepository(_envMock.Object, _nodePolicyMock.Object);
+
+        _generator = new DataSourceCodeGenerator(_dataSourceRepository, _dataNodeRepository);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _generator.Dispose();
+    }
+
+    [Test]
+    public void Codes_Assigned_Sequentially_OnAdd()
+    {
+        var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID0", Code = "A" };
+        _dataNodeRepository.AddOrUpdate(node);
+
+        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+
+        _dataSourceRepository.AddOrUpdate(ds1);
+        _dataSourceRepository.AddOrUpdate(ds2);
+
+        ds1.Code.Should().Be("A1");
+        ds2.Code.Should().Be("A2");
+    }
+
+    [Test]
+    public void Codes_Renumber_OnRemove()
+    {
+        var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID0", Code = "A" };
+        _dataNodeRepository.AddOrUpdate(node);
+
+        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        var ds3 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        _dataSourceRepository.AddOrUpdate(new[] { ds1, ds2, ds3 });
+
+        _dataSourceRepository.Remove(ds2);
+
+        ds1.Code.Should().Be("A1");
+        ds3.Code.Should().Be("A2");
+    }
+
+    [Test]
+    public void Codes_Update_WhenNodeCodeChanges()
+    {
+        var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID0", Code = "A" };
+        _dataNodeRepository.AddOrUpdate(node);
+
+        var ds1 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        var ds2 = new DataSource { DataNodeId = node.NodeId, ClientInstanceId = "CID0" };
+        _dataSourceRepository.AddOrUpdate(new[] { ds1, ds2 });
+
+        node.Code = "B";
+        _dataNodeRepository.AddOrUpdate(node);
+
+        ds1.Code.Should().Be("B1");
+        ds2.Code.Should().Be("B2");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DataSourceCodeGenerator` to keep source codes sequential per node
- wire generator into `DataSourceService`
- expose `IDataSourceCodeGenerator` interface
- add unit tests for renumbering logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860faf21c5c83338dd59e3f17409401