### PR TITLE
[feature] refresh codes after push events

### DIFF
--- a/src/ByteSync.Client/Services/Communications/PushReceivers/DataNodePushReceiver.cs
+++ b/src/ByteSync.Client/Services/Communications/PushReceivers/DataNodePushReceiver.cs
@@ -14,14 +14,16 @@ public class DataNodePushReceiver : IPushReceiver
     private readonly IDataEncrypter _dataEncrypter;
     private readonly IHubPushHandler2 _hubPushHandler2;
     private readonly IDataNodeService _dataNodeService;
+    private readonly IDataNodeCodeGenerator _codeGenerator;
 
     public DataNodePushReceiver(ISessionService sessionService, IDataEncrypter dataEncrypter,
-        IHubPushHandler2 hubPushHandler2, IDataNodeService dataNodeService)
+        IHubPushHandler2 hubPushHandler2, IDataNodeService dataNodeService, IDataNodeCodeGenerator codeGenerator)
     {
         _sessionService = sessionService;
         _dataEncrypter = dataEncrypter;
         _hubPushHandler2 = hubPushHandler2;
         _dataNodeService = dataNodeService;
+        _codeGenerator = codeGenerator;
 
         _hubPushHandler2.DataNodeAdded
             .Where(dto => _sessionService.CheckSession(dto.SessionId))
@@ -30,6 +32,7 @@ public class DataNodePushReceiver : IPushReceiver
                 var dataNode = _dataEncrypter.DecryptDataNode(dto.EncryptedDataNode);
                 dataNode.ClientInstanceId = dto.ClientInstanceId;
                 _dataNodeService.ApplyAddDataNodeLocally(dataNode);
+                _codeGenerator.RecomputeCodes();
             });
 
         _hubPushHandler2.DataNodeRemoved
@@ -39,6 +42,7 @@ public class DataNodePushReceiver : IPushReceiver
                 var dataNode = _dataEncrypter.DecryptDataNode(dto.EncryptedDataNode);
                 dataNode.ClientInstanceId = dto.ClientInstanceId;
                 _dataNodeService.ApplyRemoveDataNodeLocally(dataNode);
+                _codeGenerator.RecomputeCodes();
             });
     }
 }

--- a/src/ByteSync.Client/Services/Communications/PushReceivers/DataSourcePushReceiver.cs
+++ b/src/ByteSync.Client/Services/Communications/PushReceivers/DataSourcePushReceiver.cs
@@ -14,14 +14,16 @@ public class DataSourcePushReceiver : IPushReceiver
     private readonly IDataEncrypter _dataEncrypter;
     private readonly IHubPushHandler2 _hubPushHandler2;
     private readonly IDataSourceService _dataSourceService;
+    private readonly IDataSourceCodeGenerator _codeGenerator;
 
     public DataSourcePushReceiver(ISessionService sessionService, IDataEncrypter dataEncrypter,
-        IHubPushHandler2 hubPushHandler2, IDataSourceService dataSourceService)
+        IHubPushHandler2 hubPushHandler2, IDataSourceService dataSourceService, IDataSourceCodeGenerator codeGenerator)
     {
         _sessionService = sessionService;
         _dataEncrypter = dataEncrypter;
         _hubPushHandler2 = hubPushHandler2;
         _dataSourceService = dataSourceService;
+        _codeGenerator = codeGenerator;
         
         _hubPushHandler2.DataSourceAdded
             .Where(dto => _sessionService.CheckSession(dto.SessionId))
@@ -29,6 +31,7 @@ public class DataSourcePushReceiver : IPushReceiver
             {
                 var dataSource = _dataEncrypter.DecryptDataSource(dto.EncryptedDataSource);
                 _dataSourceService.ApplyAddDataSourceLocally(dataSource);
+                _codeGenerator.RecomputeCodesForNode(dataSource.DataNodeId);
             });
         
         _hubPushHandler2.DataSourceRemoved
@@ -37,6 +40,7 @@ public class DataSourcePushReceiver : IPushReceiver
             {
                 var dataSource = _dataEncrypter.DecryptDataSource(dto.EncryptedDataSource);
                 _dataSourceService.ApplyRemoveDataSourceLocally(dataSource);
+                _codeGenerator.RecomputeCodesForNode(dataSource.DataNodeId);
             });
     }
 }

--- a/tests/ByteSync.Client.Tests/Services/Communications/PushReceivers/DataNodePushReceiverTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/PushReceivers/DataNodePushReceiverTests.cs
@@ -1,0 +1,72 @@
+using System.Reactive.Subjects;
+using ByteSync.Business.DataNodes;
+using ByteSync.Common.Business.Sessions;
+using ByteSync.Interfaces.Controls.Communications.SignalR;
+using ByteSync.Interfaces.Controls.Encryptions;
+using ByteSync.Interfaces.Controls.Inventories;
+using ByteSync.Interfaces.Services.Sessions;
+using ByteSync.Services.Communications.PushReceivers;
+using Moq;
+using NUnit.Framework;
+
+namespace ByteSync.Tests.Services.Communications;
+
+[TestFixture]
+public class DataNodePushReceiverTests
+{
+    private Subject<DataNodeDTO> _addedSubject = null!;
+    private Subject<DataNodeDTO> _removedSubject = null!;
+    private Mock<ISessionService> _sessionServiceMock = null!;
+    private Mock<IDataEncrypter> _dataEncrypterMock = null!;
+    private Mock<IHubPushHandler2> _hubPushHandlerMock = null!;
+    private Mock<IDataNodeService> _dataNodeServiceMock = null!;
+    private Mock<IDataNodeCodeGenerator> _codeGeneratorMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _addedSubject = new Subject<DataNodeDTO>();
+        _removedSubject = new Subject<DataNodeDTO>();
+
+        _sessionServiceMock = new Mock<ISessionService>();
+        _sessionServiceMock.Setup(s => s.CheckSession(It.IsAny<string>())).Returns(true);
+        _dataEncrypterMock = new Mock<IDataEncrypter>();
+        _hubPushHandlerMock = new Mock<IHubPushHandler2>();
+        _dataNodeServiceMock = new Mock<IDataNodeService>();
+        _codeGeneratorMock = new Mock<IDataNodeCodeGenerator>();
+
+        _hubPushHandlerMock.SetupGet(h => h.DataNodeAdded).Returns(_addedSubject);
+        _hubPushHandlerMock.SetupGet(h => h.DataNodeRemoved).Returns(_removedSubject);
+
+        _ = new DataNodePushReceiver(_sessionServiceMock.Object, _dataEncrypterMock.Object,
+            _hubPushHandlerMock.Object, _dataNodeServiceMock.Object, _codeGeneratorMock.Object);
+    }
+
+    [Test]
+    public void DataNodeAdded_ShouldRefreshCodes()
+    {
+        var encrypted = new EncryptedDataNode();
+        var dto = new DataNodeDTO("SID", "CID", encrypted);
+        var node = new DataNode();
+        _dataEncrypterMock.Setup(e => e.DecryptDataNode(encrypted)).Returns(node);
+
+        _addedSubject.OnNext(dto);
+
+        _dataNodeServiceMock.Verify(s => s.ApplyAddDataNodeLocally(It.Is<DataNode>(d => d == node && d.ClientInstanceId == dto.ClientInstanceId)), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
+    }
+
+    [Test]
+    public void DataNodeRemoved_ShouldRefreshCodes()
+    {
+        var encrypted = new EncryptedDataNode();
+        var dto = new DataNodeDTO("SID", "CID", encrypted);
+        var node = new DataNode();
+        _dataEncrypterMock.Setup(e => e.DecryptDataNode(encrypted)).Returns(node);
+
+        _removedSubject.OnNext(dto);
+
+        _dataNodeServiceMock.Verify(s => s.ApplyRemoveDataNodeLocally(It.Is<DataNode>(d => d == node && d.ClientInstanceId == dto.ClientInstanceId)), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
+    }
+}

--- a/tests/ByteSync.Client.Tests/Services/Communications/PushReceivers/DataSourcePushReceiverTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/PushReceivers/DataSourcePushReceiverTests.cs
@@ -1,0 +1,73 @@
+using System.Reactive.Subjects;
+using ByteSync.Business.DataSources;
+using ByteSync.Common.Business.Inventories;
+using ByteSync.Common.Business.Sessions;
+using ByteSync.Interfaces.Controls.Communications.SignalR;
+using ByteSync.Interfaces.Controls.Encryptions;
+using ByteSync.Interfaces.Controls.Inventories;
+using ByteSync.Interfaces.Services.Sessions;
+using ByteSync.Services.Communications.PushReceivers;
+using Moq;
+using NUnit.Framework;
+
+namespace ByteSync.Tests.Services.Communications;
+
+[TestFixture]
+public class DataSourcePushReceiverTests
+{
+    private Subject<DataSourceDTO> _addedSubject = null!;
+    private Subject<DataSourceDTO> _removedSubject = null!;
+    private Mock<ISessionService> _sessionServiceMock = null!;
+    private Mock<IDataEncrypter> _dataEncrypterMock = null!;
+    private Mock<IHubPushHandler2> _hubPushHandlerMock = null!;
+    private Mock<IDataSourceService> _dataSourceServiceMock = null!;
+    private Mock<IDataSourceCodeGenerator> _codeGeneratorMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _addedSubject = new Subject<DataSourceDTO>();
+        _removedSubject = new Subject<DataSourceDTO>();
+
+        _sessionServiceMock = new Mock<ISessionService>();
+        _sessionServiceMock.Setup(s => s.CheckSession(It.IsAny<string>())).Returns(true);
+        _dataEncrypterMock = new Mock<IDataEncrypter>();
+        _hubPushHandlerMock = new Mock<IHubPushHandler2>();
+        _dataSourceServiceMock = new Mock<IDataSourceService>();
+        _codeGeneratorMock = new Mock<IDataSourceCodeGenerator>();
+
+        _hubPushHandlerMock.SetupGet(h => h.DataSourceAdded).Returns(_addedSubject);
+        _hubPushHandlerMock.SetupGet(h => h.DataSourceRemoved).Returns(_removedSubject);
+
+        _ = new DataSourcePushReceiver(_sessionServiceMock.Object, _dataEncrypterMock.Object,
+            _hubPushHandlerMock.Object, _dataSourceServiceMock.Object, _codeGeneratorMock.Object);
+    }
+
+    [Test]
+    public void DataSourceAdded_ShouldRefreshCodes()
+    {
+        var encrypted = new EncryptedDataSource();
+        var dto = new DataSourceDTO("SID", "CID", encrypted);
+        var source = new DataSource { DataNodeId = "NODE" };
+        _dataEncrypterMock.Setup(e => e.DecryptDataSource(encrypted)).Returns(source);
+
+        _addedSubject.OnNext(dto);
+
+        _dataSourceServiceMock.Verify(s => s.ApplyAddDataSourceLocally(source), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodesForNode(source.DataNodeId), Times.Once);
+    }
+
+    [Test]
+    public void DataSourceRemoved_ShouldRefreshCodes()
+    {
+        var encrypted = new EncryptedDataSource();
+        var dto = new DataSourceDTO("SID", "CID", encrypted);
+        var source = new DataSource { DataNodeId = "NODE" };
+        _dataEncrypterMock.Setup(e => e.DecryptDataSource(encrypted)).Returns(source);
+
+        _removedSubject.OnNext(dto);
+
+        _dataSourceServiceMock.Verify(s => s.ApplyRemoveDataSourceLocally(source), Times.Once);
+        _codeGeneratorMock.Verify(g => g.RecomputeCodesForNode(source.DataNodeId), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- refresh data node codes and data source codes when push events are handled
- verify push receivers call the code generation services

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615bd8736883339060f8f21c57eaf8