### PR TITLE
[test] Update inventory tests for encrypted node lists

### DIFF
--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataNodeCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataNodeCommandHandlerTests.cs
@@ -66,6 +66,8 @@ public class AddDataNodeCommandHandlerTests
         await _addDataNodeCommandHandler.Handle(request, CancellationToken.None);
 
         // Assert
+        inventoryData.InventoryMembers.Should().ContainSingle();
+        inventoryData.InventoryMembers[0].DataNodes.Should().Contain(encryptedDataNode);
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _mockInventoryRepository.AddOrUpdate(sessionId, A<Func<InventoryData?, InventoryData?>>.Ignored)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _mockInvokeClientsService.SessionGroupExcept(A<string>.Ignored, A<Client>.Ignored)).MustHaveHappenedOnceExactly();

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataSourceCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataSourceCommandHandlerTests.cs
@@ -68,6 +68,8 @@ public class AddDataSourceCommandHandlerTests
         await _addDataSourceCommandHandler.Handle(request, CancellationToken.None);
 
         // Assert
+        inventoryData.InventoryMembers.Should().ContainSingle();
+        inventoryData.InventoryMembers[0].DataSources.Should().Contain(encryptedDataSource);
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _mockInventoryRepository.AddOrUpdate(sessionId, A<Func<InventoryData?, InventoryData?>>.Ignored)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _mockInvokeClientsService.SessionGroupExcept(A<string>.Ignored, A<Client>.Ignored)).MustHaveHappenedOnceExactly();

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataNodeCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataNodeCommandHandlerTests.cs
@@ -88,6 +88,8 @@ public class RemoveDataNodeCommandHandlerTests
         await _removeDataNodeCommandHandler.Handle(request, CancellationToken.None);
 
         // Assert
+        inventoryData.InventoryMembers.Should().ContainSingle();
+        inventoryData.InventoryMembers[0].DataNodes.Should().BeEmpty();
         A.CallTo(() => _mockInventoryRepository.AddOrUpdate(sessionId, A<Func<InventoryData?, InventoryData?>>.Ignored)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _mockInventoryMemberService.GetOrCreateInventoryMember(A<InventoryData>.Ignored, sessionId, client)).MustHaveHappenedOnceExactly();
     }

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataSourceCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataSourceCommandHandlerTests.cs
@@ -91,6 +91,8 @@ public class RemoveDataSourceCommandHandlerTests
         await _removeDataSourceCommandHandler.Handle(request, CancellationToken.None);
 
         // Assert
+        inventoryData.InventoryMembers.Should().ContainSingle();
+        inventoryData.InventoryMembers[0].DataSources.Should().BeEmpty();
         A.CallTo(() => _mockInventoryRepository.AddOrUpdate(sessionId, A<Func<InventoryData?, InventoryData?>>.Ignored)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _mockInventoryMemberService.GetOrCreateInventoryMember(A<InventoryData>.Ignored, "testSession", client)).MustHaveHappenedOnceExactly();
     }


### PR DESCRIPTION
## Summary
- verify EncryptedDataNode and EncryptedDataSource lists in command handler tests

## Testing
- `dotnet test tests/ByteSync.ServerCommon.Tests/ByteSync.ServerCommon.Tests.csproj -c Release --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686231b650c4833398dc5566e25ab39a