### PR TITLE
[feature] Add encrypted data IDs

### DIFF
--- a/src/ByteSync.Client/Interfaces/Controls/Communications/Http/IInventoryApiClient.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/Http/IInventoryApiClient.cs
@@ -17,5 +17,5 @@ public interface IInventoryApiClient
 
     Task<bool> AddDataNode(string sessionId, EncryptedDataNode encryptedDataNode);
 
-    Task<bool> RemoveDataNode(string sessionId, string nodeId);
+    Task<bool> RemoveDataNode(string sessionId, EncryptedDataNode encryptedDataNode);
 }

--- a/src/ByteSync.Client/Services/Communications/Api/InventoryApiClient.cs
+++ b/src/ByteSync.Client/Services/Communications/Api/InventoryApiClient.cs
@@ -111,11 +111,11 @@ public class InventoryApiClient : IInventoryApiClient
         }
     }
 
-    public async Task<bool> RemoveDataNode(string sessionId, string nodeId)
+    public async Task<bool> RemoveDataNode(string sessionId, EncryptedDataNode encryptedDataNode)
     {
         try
         {
-            var result = await _apiInvoker.DeleteAsync<bool>($"session/{sessionId}/inventory/dataNode/{nodeId}", null);
+            var result = await _apiInvoker.DeleteAsync<bool>($"session/{sessionId}/inventory/dataNode", encryptedDataNode);
 
             return result;
         }

--- a/src/ByteSync.Client/Services/Encryptions/DataEncrypter.cs
+++ b/src/ByteSync.Client/Services/Encryptions/DataEncrypter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Security.Cryptography;
 using ByteSync.Business.DataSources;
 using ByteSync.Business.SessionMembers;
@@ -85,6 +86,7 @@ public class DataEncrypter : IDataEncrypter
         }
         
         var encryptedData = new T();
+        encryptedData.Id = Guid.NewGuid().ToString();
         encryptedData.IV = aes.IV;
         encryptedData.Data = ms.ToArray();
 

--- a/src/ByteSync.Client/Services/Encryptions/DataEncrypter.cs
+++ b/src/ByteSync.Client/Services/Encryptions/DataEncrypter.cs
@@ -35,10 +35,7 @@ public class DataEncrypter : IDataEncrypter
 
     public EncryptedDataSource EncryptDataSource(DataSource dataSource)
     {
-        var encryptedDataSource = Encrypt<EncryptedDataSource>(dataSource);
-        encryptedDataSource.Code = dataSource.Code;
-
-        return encryptedDataSource;
+        return Encrypt<EncryptedDataSource>(dataSource);
     }
 
     public EncryptedDataNode EncryptDataNode(DataNode dataNode)
@@ -48,10 +45,7 @@ public class DataEncrypter : IDataEncrypter
 
     public DataSource DecryptDataSource(EncryptedDataSource encryptedDataSource)
     {
-        var dataSource = Decrypt<DataSource>(encryptedDataSource);
-        dataSource.Code = encryptedDataSource.Code;
-
-        return dataSource;
+       return Decrypt<DataSource>(encryptedDataSource);
     }
 
     public DataNode DecryptDataNode(EncryptedDataNode encryptedDataNode)

--- a/src/ByteSync.Client/Services/Inventories/DataNodeService.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataNodeService.cs
@@ -68,7 +68,8 @@ public class DataNodeService : IDataNodeService
         if (_sessionService.CurrentSession is CloudSession cloudSession
             && dataNode.ClientInstanceId == _connectionService.ClientInstanceId)
         {
-            isRemoveOK = await _inventoryApiClient.RemoveDataNode(cloudSession.SessionId, dataNode.NodeId);
+            var encryptedDataNode = _dataEncrypter.EncryptDataNode(dataNode);
+            isRemoveOK = await _inventoryApiClient.RemoveDataNode(cloudSession.SessionId, encryptedDataNode);
         }
 
         if (isRemoveOK)

--- a/src/ByteSync.Client/Services/Inventories/DataSourceService.cs
+++ b/src/ByteSync.Client/Services/Inventories/DataSourceService.cs
@@ -110,10 +110,6 @@ public class DataSourceService : IDataSourceService
         dataSource.DataNodeId = dataNode.NodeId;
         dataSource.InitialTimestamp = DateTime.UtcNow;
 
-        // var sessionMemberInfo = _dataNodeRepository.GetCurrentSessionMember();
-        // dataSource.Code = sessionMemberInfo.GetLetter() +
-        //                 (_dataSourceRepository.Elements.Count(ds => ds.BelongsTo(sessionMemberInfo)) + 1);
-
         return TryAddDataSource(dataSource);
     }
 
@@ -135,5 +131,4 @@ public class DataSourceService : IDataSourceService
         _dataSourceRepository.Remove(dataSource);
         _codeGenerator.RecomputeCodesForNode(dataSource.DataNodeId);
     }
-
 }

--- a/src/ByteSync.Common/Business/Inventories/EncryptedDataSource.cs
+++ b/src/ByteSync.Common/Business/Inventories/EncryptedDataSource.cs
@@ -9,10 +9,4 @@ public class EncryptedDataSource : IEncryptedSessionData
     public byte[] Data { get; set; }
     
     public byte[] IV { get; set; }
-    
-    public string Code
-    {
-        get;
-        set;
-    }
 }

--- a/src/ByteSync.Common/Business/Inventories/EncryptedDataSource.cs
+++ b/src/ByteSync.Common/Business/Inventories/EncryptedDataSource.cs
@@ -4,6 +4,8 @@ namespace ByteSync.Common.Business.Inventories;
 
 public class EncryptedDataSource : IEncryptedSessionData
 {
+    public string Id { get; set; } = null!;
+
     public byte[] Data { get; set; }
     
     public byte[] IV { get; set; }

--- a/src/ByteSync.Common/Business/Sessions/EncryptedDataNode.cs
+++ b/src/ByteSync.Common/Business/Sessions/EncryptedDataNode.cs
@@ -4,6 +4,8 @@ namespace ByteSync.Common.Business.Sessions;
 
 public class EncryptedDataNode : IEncryptedSessionData
 {
+    public string Id { get; set; } = null!;
+
     public byte[] Data { get; set; } = null!;
 
     public byte[] IV { get; set; } = null!;

--- a/src/ByteSync.Common/Business/Sessions/EncryptedSessionMemberPrivateData.cs
+++ b/src/ByteSync.Common/Business/Sessions/EncryptedSessionMemberPrivateData.cs
@@ -4,6 +4,8 @@ namespace ByteSync.Common.Business.Sessions;
 
 public class EncryptedSessionMemberPrivateData : IEncryptedSessionData
 {
+    public string Id { get; set; } = null!;
+
     public byte[] Data { get; set; }
     
     public byte[] IV { get; set; }

--- a/src/ByteSync.Common/Business/Sessions/EncryptedSessionSettings.cs
+++ b/src/ByteSync.Common/Business/Sessions/EncryptedSessionSettings.cs
@@ -4,6 +4,8 @@ namespace ByteSync.Common.Business.Sessions;
 
 public class EncryptedSessionSettings : IEncryptedSessionData
 {
+    public string Id { get; set; } = null!;
+
     public byte[] Data { get; set; } = null!;
     
     public byte[] IV { get; set; } = null!;

--- a/src/ByteSync.Common/Interfaces/Business/IEncryptedSessionData.cs
+++ b/src/ByteSync.Common/Interfaces/Business/IEncryptedSessionData.cs
@@ -2,6 +2,11 @@
 
 public interface IEncryptedSessionData
 {
+    /// <summary>
+    /// Unique identifier of the encrypted payload.
+    /// </summary>
+    public string Id { get; set; }
+
     // public string SessionId { get; set; }
     
     public byte[] Data { get; set; }

--- a/src/ByteSync.Functions/Http/InventoryFunction.cs
+++ b/src/ByteSync.Functions/Http/InventoryFunction.cs
@@ -85,7 +85,7 @@ public class InventoryFunction
         var client = FunctionHelper.GetClientFromContext(executionContext);
         var encryptedDataSource = await FunctionHelper.DeserializeRequestBody<EncryptedDataSource>(req);
 
-        var request = new RemoveDataSourceRequest(sessionId, client, client.ClientInstanceId, encryptedDataSource);
+        var request = new RemoveDataSourceRequest(sessionId, client, encryptedDataSource);
         var result = await _mediator.Send(request);
         
         var response = req.CreateResponse();
@@ -132,15 +132,15 @@ public class InventoryFunction
 
     [Function("InventoryRemoveDataNodeFunction")]
     public async Task<HttpResponseData> RemoveDataNode(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "session/{sessionId}/inventory/dataNode/{nodeId}")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "session/{sessionId}/inventory/dataNode")]
         HttpRequestData req,
         FunctionContext executionContext,
-        string sessionId,
-        string nodeId)
+        string sessionId)
     {
         var client = FunctionHelper.GetClientFromContext(executionContext);
+        var encryptedDataNode = await FunctionHelper.DeserializeRequestBody<EncryptedDataNode>(req);
 
-        var request = new RemoveDataNodeRequest(sessionId, client, nodeId);
+        var request = new RemoveDataNodeRequest(sessionId, client, encryptedDataNode);
         var result = await _mediator.Send(request);
 
         var response = req.CreateResponse();

--- a/src/ByteSync.ServerCommon/Business/Sessions/InventoryData.cs
+++ b/src/ByteSync.ServerCommon/Business/Sessions/InventoryData.cs
@@ -17,22 +17,4 @@ public class InventoryData
     public List<InventoryMemberData> InventoryMembers { get; set; }
     
     public bool IsInventoryStarted { get; set; }
-    
-    public void RecodeDataSources(CloudSessionData cloudSessionData)
-    {
-        foreach (var inventoryMemberData in InventoryMembers)
-        {
-            int position = cloudSessionData.SessionMembers.FindIndex(m => m.ClientInstanceId == inventoryMemberData.ClientInstanceId);
-
-            string letter = ((char)('A' + position)).ToString();
-
-            int cpt = 1;
-            foreach (var dataSource in inventoryMemberData.DataSources)
-            {
-                dataSource.Code = letter + cpt;
-
-                cpt += 1;
-            }
-        }
-    }
 }

--- a/src/ByteSync.ServerCommon/Commands/CloudSessions/QuitSessionCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/CloudSessions/QuitSessionCommandHandler.cs
@@ -72,8 +72,6 @@ public class QuitSessionCommandHandler : IRequestHandler<QuitSessionRequest>
                     inventoryData.InventoryMembers.Remove(inventoryMember);
                 }
 
-                inventoryData.RecodeDataSources(innerCloudSessionData!);
-
                 return true;
             }, transaction);
         }

--- a/src/ByteSync.ServerCommon/Commands/Inventories/AddDataNodeCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/AddDataNodeCommandHandler.cs
@@ -50,6 +50,7 @@ public class AddDataNodeCommandHandler : IRequestHandler<AddDataNodeRequest, boo
             {
                 var inventoryMember = _inventoryMemberService.GetOrCreateInventoryMember(inventoryData, sessionId, client);
 
+                inventoryMember.DataNodes.RemoveAll(n => n.Id == encryptedDataNode.Id);
                 inventoryMember.DataNodes.Add(encryptedDataNode);
 
                 return inventoryData;

--- a/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
@@ -54,8 +54,6 @@ public class AddDataSourceCommandHandler : IRequestHandler<AddDataSourceRequest,
 
                 inventoryMember.DataSources.RemoveAll(p => p.Id == encryptedDataSource.Id);
                 inventoryMember.DataSources.Add(encryptedDataSource);
-
-                inventoryData.RecodeDataSources(cloudSessionData);
                 
                 return inventoryData;
             }

--- a/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/AddDataSourceCommandHandler.cs
@@ -52,7 +52,7 @@ public class AddDataSourceCommandHandler : IRequestHandler<AddDataSourceRequest,
             {
                 var inventoryMember = _inventoryMemberService.GetOrCreateInventoryMember(inventoryData, sessionId, client);
 
-                inventoryMember.DataSources.RemoveAll(p => p.Code == encryptedDataSource.Code);
+                inventoryMember.DataSources.RemoveAll(p => p.Id == encryptedDataSource.Id);
                 inventoryMember.DataSources.Add(encryptedDataSource);
 
                 inventoryData.RecodeDataSources(cloudSessionData);

--- a/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataNodeCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataNodeCommandHandler.cs
@@ -53,9 +53,13 @@ public class RemoveDataNodeCommandHandler : IRequestHandler<RemoveDataNodeReques
 
                 if (inventoryMember.DataNodes.Any())
                 {
-                    removedDataNode = inventoryMember.DataNodes.First();
-                    inventoryMember.DataNodes.Clear();
-                    inventoryMember.DataSources.Clear();
+                    var index = inventoryMember.DataNodes.FindIndex(n => n.Id == request.NodeId);
+                    if (index >= 0)
+                    {
+                        removedDataNode = inventoryMember.DataNodes[index];
+                        inventoryMember.DataNodes.RemoveAt(index);
+                        inventoryMember.DataSources.Clear();
+                    }
                 }
 
                 return inventoryData;

--- a/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataNodeCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataNodeCommandHandler.cs
@@ -51,16 +51,7 @@ public class RemoveDataNodeCommandHandler : IRequestHandler<RemoveDataNodeReques
             {
                 var inventoryMember = _inventoryMemberService.GetOrCreateInventoryMember(inventoryData, sessionId, client);
 
-                if (inventoryMember.DataNodes.Any())
-                {
-                    var index = inventoryMember.DataNodes.FindIndex(n => n.Id == request.NodeId);
-                    if (index >= 0)
-                    {
-                        removedDataNode = inventoryMember.DataNodes[index];
-                        inventoryMember.DataNodes.RemoveAt(index);
-                        inventoryMember.DataSources.Clear();
-                    }
-                }
+                inventoryMember.DataNodes.RemoveAll(p => p.Id == request.EncryptedDataNode.Id);
 
                 return inventoryData;
             }

--- a/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataNodeRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataNodeRequest.cs
@@ -1,3 +1,4 @@
+using ByteSync.Common.Business.Sessions;
 using ByteSync.ServerCommon.Business.Auth;
 using MediatR;
 
@@ -5,16 +6,16 @@ namespace ByteSync.ServerCommon.Commands.Inventories;
 
 public class RemoveDataNodeRequest : IRequest<bool>
 {
-    public RemoveDataNodeRequest(string sessionId, Client client, string nodeId)
+    public RemoveDataNodeRequest(string sessionId, Client client, EncryptedDataNode encryptedDataNode)
     {
         SessionId = sessionId;
         Client = client;
-        NodeId = nodeId;
+        EncryptedDataNode = encryptedDataNode;
     }
 
     public string SessionId { get; }
 
     public Client Client { get; }
-
-    public string NodeId { get; }
+    
+    public EncryptedDataNode EncryptedDataNode { get; }
 }

--- a/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceCommandHandler.cs
@@ -50,8 +50,6 @@ public class RemoveDataSourceCommandHandler : IRequestHandler<RemoveDataSourceRe
 
                 inventoryMember.DataSources.RemoveAll(p => p.Id == request.EncryptedDataSource.Id);
 
-                inventoryData.RecodeDataSources(cloudSessionData);
-
                 return inventoryData;
             }
             else

--- a/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceCommandHandler.cs
@@ -48,7 +48,7 @@ public class RemoveDataSourceCommandHandler : IRequestHandler<RemoveDataSourceRe
             {
                 var inventoryMember = _inventoryMemberService.GetOrCreateInventoryMember(inventoryData, request.SessionId, request.Client);
 
-                inventoryMember.DataSources.RemoveAll(p => p.Code == request.EncryptedDataSource.Code);
+                inventoryMember.DataSources.RemoveAll(p => p.Id == request.EncryptedDataSource.Id);
 
                 inventoryData.RecodeDataSources(cloudSessionData);
 

--- a/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Inventories/RemoveDataSourceRequest.cs
@@ -6,19 +6,16 @@ namespace ByteSync.ServerCommon.Commands.Inventories;
 
 public class RemoveDataSourceRequest : IRequest<bool>
 {
-    public RemoveDataSourceRequest(string sessionId, Client client, string nodeId, EncryptedDataSource encryptedDataSource)
+    public RemoveDataSourceRequest(string sessionId, Client client, EncryptedDataSource encryptedDataSource)
     {
         SessionId = sessionId;
         Client = client;
-        NodeId = nodeId;
         EncryptedDataSource = encryptedDataSource;
     }
     
     public string SessionId { get; }
     
     public Client Client { get; }
-
-    public string NodeId { get; }
     
     public EncryptedDataSource EncryptedDataSource { get; }
 }

--- a/src/ByteSync.ServerCommon/Helpers/LogHelper.cs
+++ b/src/ByteSync.ServerCommon/Helpers/LogHelper.cs
@@ -89,18 +89,18 @@ public static class LogHelper
         };
     }
 
-    public static object BuildLog(this EncryptedDataSource sharedDataSource)
-    {
-        if (sharedDataSource == null)
-        {
-            return null;
-        }
-
-        return new
-        {
-            Code = sharedDataSource.Code,
-        };
-    }
+    // public static object BuildLog(this EncryptedDataSource sharedDataSource)
+    // {
+    //     if (sharedDataSource == null)
+    //     {
+    //         return null;
+    //     }
+    //
+    //     return new
+    //     {
+    //         Code = sharedDataSource.Code,
+    //     };
+    // }
 
     // public static object BuildLog(this ProductSerial productSerial)
     // {

--- a/tests/ByteSync.Client.IntegrationTests/Services/Inventories/TestDataNodeService.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Inventories/TestDataNodeService.cs
@@ -96,13 +96,13 @@ public class TestDataNodeService : IntegrationTest
         var apiClient = Container.Resolve<Mock<IInventoryApiClient>>();
         var node = new DataNode { NodeId = "NODE", ClientInstanceId = _currentEndPoint.ClientInstanceId };
         repository.AddOrUpdate(node);
-        apiClient.Setup(a => a.RemoveDataNode(_sessionId, node.NodeId)).ReturnsAsync(true);
+        apiClient.Setup(a => a.RemoveDataNode(_sessionId, It.IsAny<EncryptedDataNode>())).ReturnsAsync(true);
 
         var result = await _service.TryRemoveDataNode(node);
 
         result.Should().BeTrue();
         repository.Elements.Should().BeEmpty();
-        apiClient.Verify(a => a.RemoveDataNode(_sessionId, node.NodeId), Times.Once);
+        apiClient.Verify(a => a.RemoveDataNode(_sessionId, It.IsAny<EncryptedDataNode>()), Times.Once);
     }
 
     [Test]

--- a/tests/ByteSync.Client.Tests/Services/Inventories/DataNodeServiceTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Inventories/DataNodeServiceTests.cs
@@ -109,13 +109,13 @@ public class DataNodeServiceTests
             .Returns(new CloudSession { SessionId = sessionId });
         _connectionServiceMock.SetupGet(c => c.ClientInstanceId).Returns("CID");
         var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID" };
-        _inventoryApiClientMock.Setup(a => a.RemoveDataNode(sessionId, node.NodeId))
+        _inventoryApiClientMock.Setup(a => a.RemoveDataNode(sessionId, It.IsAny<EncryptedDataNode>()))
             .ReturnsAsync(true);
 
         var result = await _service.TryRemoveDataNode(node);
 
         result.Should().BeTrue();
-        _inventoryApiClientMock.Verify(a => a.RemoveDataNode(sessionId, node.NodeId), Times.Once);
+        _inventoryApiClientMock.Verify(a => a.RemoveDataNode(sessionId, It.IsAny<EncryptedDataNode>()), Times.Once);
         _dataNodeRepositoryMock.Verify(r => r.Remove(node), Times.Once);
         _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
     }
@@ -132,7 +132,7 @@ public class DataNodeServiceTests
         var result = await _service.TryRemoveDataNode(node);
 
         result.Should().BeTrue();
-        _inventoryApiClientMock.Verify(a => a.RemoveDataNode(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _inventoryApiClientMock.Verify(a => a.RemoveDataNode(It.IsAny<string>(), It.IsAny<EncryptedDataNode>()), Times.Never);
         _dataNodeRepositoryMock.Verify(r => r.Remove(node), Times.Once);
         _codeGeneratorMock.Verify(g => g.RecomputeCodes(), Times.Once);
     }
@@ -145,7 +145,7 @@ public class DataNodeServiceTests
             .Returns(new CloudSession { SessionId = sessionId });
         _connectionServiceMock.SetupGet(c => c.ClientInstanceId).Returns("CID");
         var node = new DataNode { NodeId = "N1", ClientInstanceId = "CID" };
-        _inventoryApiClientMock.Setup(a => a.RemoveDataNode(sessionId, node.NodeId))
+        _inventoryApiClientMock.Setup(a => a.RemoveDataNode(sessionId, It.IsAny<EncryptedDataNode>()))
             .ReturnsAsync(false);
 
         var result = await _service.TryRemoveDataNode(node);

--- a/tests/ByteSync.ServerCommon.Tests/Commands/CloudSessions/QuitSessionCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/CloudSessions/QuitSessionCommandHandlerTests.cs
@@ -243,8 +243,8 @@ public async Task QuitSession_WithDataSources_NotifiesDataSourceRemoved()
     // Create inventory data with path items
     var inventoryData = new InventoryData(sessionId);
     var inventoryMember = new InventoryMemberData { ClientInstanceId = "clientInstance1" };
-    var dataSource1 = new EncryptedDataSource { Code = "path1", Data = new byte[] { 1, 2, 3 }, IV = new byte[] { 4, 5, 6 } };
-    var dataSource2 = new EncryptedDataSource { Code = "path2", Data = new byte[] { 7, 8, 9 }, IV = new byte[] { 10, 11, 12 } };
+    var dataSource1 = new EncryptedDataSource { Id = "path1", Data = new byte[] { 1, 2, 3 }, IV = new byte[] { 4, 5, 6 } };
+    var dataSource2 = new EncryptedDataSource { Id = "path2", Data = new byte[] { 7, 8, 9 }, IV = new byte[] { 10, 11, 12 } };
     inventoryMember.DataSources.Add(dataSource1);
     inventoryMember.DataSources.Add(dataSource2);
     inventoryData.InventoryMembers.Add(inventoryMember);
@@ -299,7 +299,7 @@ public async Task QuitSession_WithDataSources_NotifiesDataSourceRemoved()
     A.CallTo(() => mockGroup.DataSourceRemoved(A<DataSourceDTO>.That.Matches(dto => 
         dto.SessionId == sessionId && 
         dto.ClientInstanceId == client.ClientInstanceId && 
-        (dto.EncryptedDataSource.Code == "path1" || dto.EncryptedDataSource.Code == "path2"))))
+        (dto.EncryptedDataSource.Id == "path1" || dto.EncryptedDataSource.Id == "path2"))))
         .MustHaveHappened(2, Times.Exactly);
-}
+    }
 }

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataSourceCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/AddDataSourceCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public class AddDataSourceCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var encryptedDataSource = new EncryptedDataSource { Id = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
@@ -82,7 +82,7 @@ public class AddDataSourceCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var encryptedDataSource = new EncryptedDataSource { Id = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.IsInventoryStarted = true;
 
@@ -112,7 +112,7 @@ public class AddDataSourceCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var encryptedDataSource = new EncryptedDataSource { Id = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData
             { ClientInstanceId = client.ClientInstanceId, DataSources = [ encryptedDataSource ] });

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/GetPathItemsCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/GetPathItemsCommandHandlerTests.cs
@@ -34,7 +34,7 @@ public class GetDataSourcesCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var encryptedDataSource = new EncryptedDataSource { Id = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData
             { ClientInstanceId = client.ClientInstanceId, DataSources = [ encryptedDataSource ] });
@@ -82,7 +82,7 @@ public class GetDataSourcesCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var dataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var dataSource = new EncryptedDataSource { Id = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId, DataSources = [ dataSource ] });
 

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataNodeCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataNodeCommandHandlerTests.cs
@@ -40,6 +40,7 @@ public class RemoveDataNodeCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
+        var encryptedDataNode = new EncryptedDataNode{ Id = "dataNode1" };
         var inventoryData = new InventoryData(sessionId);
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
@@ -52,7 +53,7 @@ public class RemoveDataNodeCommandHandlerTests
         A.CallTo(() => _mockInventoryMemberService.GetOrCreateInventoryMember(A<InventoryData>.Ignored, sessionId, client))
             .Returns(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId });
 
-        var request = new RemoveDataNodeRequest(sessionId, client, "NID_1");
+        var request = new RemoveDataNodeRequest(sessionId, client, encryptedDataNode);
 
         // Act
         await _removeDataNodeCommandHandler.Handle(request, CancellationToken.None);
@@ -68,7 +69,7 @@ public class RemoveDataNodeCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var encryptedDataNode = new EncryptedDataNode();
+        var encryptedDataNode = new EncryptedDataNode{ Id = "dataNode1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId, DataNodes = [ encryptedDataNode ], DataSources = [] });
 
@@ -82,7 +83,7 @@ public class RemoveDataNodeCommandHandlerTests
         A.CallTo(() => _mockInventoryMemberService.GetOrCreateInventoryMember(A<InventoryData>.Ignored, sessionId, client))
             .Returns(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId });
 
-        var request = new RemoveDataNodeRequest(sessionId, client, "NID_1");
+        var request = new RemoveDataNodeRequest(sessionId, client, encryptedDataNode);
 
         // Act
         await _removeDataNodeCommandHandler.Handle(request, CancellationToken.None);

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataSourceCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/RemoveDataSourceCommandHandlerTests.cs
@@ -41,7 +41,7 @@ public class RemoveDataSourceCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var encryptedDataSource = new EncryptedDataSource { Id = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
@@ -54,7 +54,7 @@ public class RemoveDataSourceCommandHandlerTests
         A.CallTo(() => _mockInventoryMemberService.GetOrCreateInventoryMember(A<InventoryData>.Ignored, "testSession", client))
             .Returns(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId });
 
-        var request = new RemoveDataSourceRequest(sessionId, client, client.ClientInstanceId, encryptedDataSource);
+        var request = new RemoveDataSourceRequest(sessionId, client, encryptedDataSource);
 
         // Act
         await _removeDataSourceCommandHandler.Handle(request, CancellationToken.None);
@@ -70,7 +70,7 @@ public class RemoveDataSourceCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var client = new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" };
-        var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var encryptedDataSource = new EncryptedDataSource { Id = "dataSource1" };
         var inventoryData = new InventoryData(sessionId);
         inventoryData.InventoryMembers.Add(new InventoryMemberData
             { ClientInstanceId = client.ClientInstanceId, DataSources = [ encryptedDataSource ] });
@@ -85,7 +85,7 @@ public class RemoveDataSourceCommandHandlerTests
         A.CallTo(() => _mockInventoryMemberService.GetOrCreateInventoryMember(A<InventoryData>.Ignored, "testSession", client))
             .Returns(new InventoryMemberData { ClientInstanceId = client.ClientInstanceId });
 
-        var request = new RemoveDataSourceRequest(sessionId, client, client.ClientInstanceId, encryptedDataSource);
+        var request = new RemoveDataSourceRequest(sessionId, client, encryptedDataSource);
 
         // Act
         await _removeDataSourceCommandHandler.Handle(request, CancellationToken.None);

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/StartInventoryCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Inventories/StartInventoryCommandHandlerTests.cs
@@ -210,7 +210,7 @@ public class StartInventoryCommandHandlerTests
         // Arrange
         var sessionId = "testSession";
         var inventoryData = new InventoryData(sessionId);
-        var encryptedDataSource = new EncryptedDataSource { Code = "dataSource1" };
+        var encryptedDataSource = new EncryptedDataSource { Id = "dataSource1" };
         var cloudSessionData = new CloudSessionData(null, new EncryptedSessionSettings(),
             new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" });
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
@@ -251,9 +251,9 @@ public class StartInventoryCommandHandlerTests
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client2", "client2", new PublicKeyInfo(), null, cloudSessionData));
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client1", DataSources = [ new() { Code = "dataSource1" } ] });
+            { ClientInstanceId = "client1", DataSources = [ new() { Id = "dataSource1" } ] });
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client2", DataSources = [ new() { Code = "dataSource2" } ] });
+            { ClientInstanceId = "client2", DataSources = [ new() { Id = "dataSource2" } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(cloudSessionData);
@@ -325,7 +325,7 @@ public class StartInventoryCommandHandlerTests
             new Client { ClientId = "client1", ClientInstanceId = "clientInstanceId1" });
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client1", DataSources = [ new() { Code = "dataSource1" } ] });
+            { ClientInstanceId = "client1", DataSources = [ new() { Id = "dataSource1" } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(cloudSessionData);
@@ -362,9 +362,9 @@ public class StartInventoryCommandHandlerTests
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client1", "client1", new PublicKeyInfo(), null, cloudSessionData));
         cloudSessionData.SessionMembers.Add(new SessionMemberData("client2", "client2", new PublicKeyInfo(), null, cloudSessionData));
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client1", DataSources = [ new() { Code = "dataSource1" } ] });
+            { ClientInstanceId = "client1", DataSources = [ new() { Id = "dataSource1" } ] });
         inventoryData.InventoryMembers.Add(new InventoryMemberData
-            { ClientInstanceId = "client2", DataSources = [ new() { Code = "dataSource2" } ] });
+            { ClientInstanceId = "client2", DataSources = [ new() { Id = "dataSource2" } ] });
 
         A.CallTo(() => _mockCloudSessionsRepository.Get(sessionId))
             .Returns(cloudSessionData);


### PR DESCRIPTION
## Summary
- add `Id` to `IEncryptedSessionData` and implementing classes
- assign a GUID when encrypting data
- use the new `Id` when adding or removing data nodes or sources

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68637470d9ac83339fa4f09665d9cf66