### PR TITLE
[feature] Add refresh of server messages

### DIFF
--- a/docs/client-deployment.md
+++ b/docs/client-deployment.md
@@ -25,11 +25,12 @@ These projects are written in **C#** and target a specific version of **.NET**. 
    {
      "LocalDebugUrl": "",
      "DevelopmentUrl": "",
-     "StagingUrl": "",
-     "ProductionUrl": "",
-     "UpdatesDefinitionUrl": ""
-   }
-   ```
+  "StagingUrl": "",
+  "ProductionUrl": "",
+  "UpdatesDefinitionUrl": "",
+  "MessagesDefinitionsUrl": ""
+  }
+  ```
 
    Fill in any relevant URLs or other settings your environment requires.
 

--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -71,7 +71,8 @@ Below is the JSON structure indicating which properties must be set. In particul
     "DatabaseName": ""
   },
   "AppSettings": {
-    "Secret": "YOUR_UNIQUE_RANDOM_SEED"
+    "Secret": "YOUR_UNIQUE_RANDOM_SEED",
+    "MessagesDefinitionsUrl": ""
   }
 }
 ```
@@ -97,7 +98,8 @@ Below is the JSON structure indicating which properties must be set. In particul
     "SignalR:ConnectionString": "<your-signalr-connection-string>",
     "CosmosDb:ConnectionString": "<your-cosmosdb-connection-string>",
     "CosmosDb:DatabaseName": "<your-database-name>",
-    "AppSettings:Secret": "YOUR_UNIQUE_RANDOM_SEED"
+    "AppSettings:Secret": "YOUR_UNIQUE_RANDOM_SEED",
+    "AppSettings:MessagesDefinitionsUrl": ""
   }
 }
 ```
@@ -136,6 +138,7 @@ cd ByteSync.Functions
 
 # App Settings
   dotnet user-secrets set "AppSettings:Secret" "YOUR_UNIQUE_RANDOM_SEED"
+  dotnet user-secrets set "AppSettings:MessagesDefinitionsUrl" ""
 ```
 
 Repeat these steps for **ByteSync.Functions.IntegrationTests** and **ByteSync.ServerCommon.Tests**, navigating to each project's directory and setting the same secrets.

--- a/src/ByteSync.Client/local.settings.template.json
+++ b/src/ByteSync.Client/local.settings.template.json
@@ -3,5 +3,6 @@
   "DevelopmentUrl": "",
   "StagingUrl": "",
   "ProductionUrl": "",
-  "UpdatesDefinitionUrl": ""
+  "UpdatesDefinitionUrl": "",
+  "MessagesDefinitionsUrl": ""
 }

--- a/src/ByteSync.Common/Controls/Json/JsonSerializerOptionsHelper.cs
+++ b/src/ByteSync.Common/Controls/Json/JsonSerializerOptionsHelper.cs
@@ -21,6 +21,8 @@ public static class JsonSerializerOptionsHelper
         options.Converters.Add(new JsonStringEnumConverter());
         options.Converters.Add(new UtcDateTimeConverter());
         
+        options.PropertyNameCaseInsensitive = true;
+        
         options.IgnoreReadOnlyProperties = true;
         options.IgnoreReadOnlyFields = true;
     }

--- a/src/ByteSync.Functions/Helpers/Loaders/DependencyInjectionLoader.cs
+++ b/src/ByteSync.Functions/Helpers/Loaders/DependencyInjectionLoader.cs
@@ -37,6 +37,12 @@ public static class DependencyInjectionLoader
                 .InstancePerLifetimeScope();
         }
     
+        builder.Register(c =>
+        {
+            var factory = c.Resolve<IHttpClientFactory>();
+            return factory.CreateClient();
+        }).As<HttpClient>().InstancePerLifetimeScope();
+        
         builder.RegisterAssemblyTypes(executingAssembly)
             .Where(t => t.Name.EndsWith("Service"))
             .InstancePerLifetimeScope()

--- a/src/ByteSync.Functions/Program.cs
+++ b/src/ByteSync.Functions/Program.cs
@@ -51,6 +51,7 @@ var host = new HostBuilder()
     {
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
+        services.AddHttpClient();
         
         services.Configure<LoggerFilterOptions>(options =>
         {

--- a/src/ByteSync.Functions/Timer/RefreshMessageDefinitionsFunction.cs
+++ b/src/ByteSync.Functions/Timer/RefreshMessageDefinitionsFunction.cs
@@ -1,0 +1,39 @@
+using ByteSync.ServerCommon.Business.Messages;
+using ByteSync.ServerCommon.Interfaces.Loaders;
+using ByteSync.ServerCommon.Interfaces.Repositories;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace ByteSync.Functions.Timer;
+
+public class RefreshMessageDefinitionsFunction
+{
+    private readonly IMessageDefinitionsLoader _loader;
+    private readonly IMessageDefinitionRepository _repository;
+    private readonly ILogger<RefreshMessageDefinitionsFunction> _logger;
+
+    public RefreshMessageDefinitionsFunction(IMessageDefinitionsLoader loader, IMessageDefinitionRepository repository,
+        ILogger<RefreshMessageDefinitionsFunction> logger)
+    {
+        _loader = loader;
+        _repository = repository;
+        _logger = logger;
+    }
+
+    [Function("RefreshMessageDefinitionsFunction")]
+    public async Task<int> RunAsync([TimerTrigger("0 0 */2 * * *"
+#if DEBUG
+        , RunOnStartup = true
+#endif
+        )] TimerInfo timerInfo)
+    {
+        _logger.LogInformation("Refreshing message definitions at: {Now}", DateTime.UtcNow);
+
+        var definitions = await _loader.Load();
+        var valid = definitions.Where(d => d.EndDate > DateTime.UtcNow).ToList();
+
+        await _repository.SaveAll(valid);
+
+        return valid.Count;
+    }
+}

--- a/src/ByteSync.Functions/Timer/RefreshMessageDefinitionsFunction.cs
+++ b/src/ByteSync.Functions/Timer/RefreshMessageDefinitionsFunction.cs
@@ -29,11 +29,11 @@ public class RefreshMessageDefinitionsFunction
     {
         _logger.LogInformation("Refreshing message definitions at: {Now}", DateTime.UtcNow);
 
-        var definitions = await _loader.Load();
-        var valid = definitions.Where(d => d.EndDate > DateTime.UtcNow).ToList();
+        var messageDefinitions = await _loader.Load();
+        var validMessageDefinitions = messageDefinitions.Where(d => d.EndDate > DateTime.UtcNow).ToList();
 
-        await _repository.SaveAll(valid);
+        await _repository.SaveAll(validMessageDefinitions);
 
-        return valid.Count;
+        return validMessageDefinitions.Count;
     }
 }

--- a/src/ByteSync.ServerCommon/Business/Messages/MessageDefinition.cs
+++ b/src/ByteSync.ServerCommon/Business/Messages/MessageDefinition.cs
@@ -2,6 +2,8 @@ namespace ByteSync.ServerCommon.Business.Messages;
 
 public class MessageDefinition
 {
+    public string Id { get; set; }
+    
     public DateTime StartDate { get; set; }
 
     public DateTime EndDate { get; set; }

--- a/src/ByteSync.ServerCommon/Business/Messages/MessageDefinition.cs
+++ b/src/ByteSync.ServerCommon/Business/Messages/MessageDefinition.cs
@@ -1,0 +1,10 @@
+namespace ByteSync.ServerCommon.Business.Messages;
+
+public class MessageDefinition
+{
+    public DateTime StartDate { get; set; }
+
+    public DateTime EndDate { get; set; }
+
+    public Dictionary<string, string> Message { get; set; } = new();
+}

--- a/src/ByteSync.ServerCommon/Business/Settings/AppSettings.cs
+++ b/src/ByteSync.ServerCommon/Business/Settings/AppSettings.cs
@@ -7,6 +7,8 @@ public class AppSettings
     public int JwtDurationInSeconds { get; set; } = 3600;
     
     public bool SkipClientsVersionCheck { get; set; } = false;
-    
+
     public string UpdatesDefinitionUrl { get; set; } = "";
+
+    public string MessagesDefinitionsUrl { get; set; } = "";
 }

--- a/src/ByteSync.ServerCommon/Entities/EntityType.cs
+++ b/src/ByteSync.ServerCommon/Entities/EntityType.cs
@@ -11,5 +11,6 @@ public enum EntityType
     Client,
     ClientSoftwareVersionSettings,
     CloudSessionProfile,
-    Lobby
+    Lobby,
+    MessageDefinition
 }

--- a/src/ByteSync.ServerCommon/Factories/CacheKeyFactory.cs
+++ b/src/ByteSync.ServerCommon/Factories/CacheKeyFactory.cs
@@ -51,6 +51,7 @@ public class CacheKeyFactory : ICacheKeyFactory
             EntityType.ClientSoftwareVersionSettings => "ClientSoftwareVersionSettings",
             EntityType.CloudSessionProfile => "CloudSessionProfile",
             EntityType.Lobby => "Lobby",
+            EntityType.MessageDefinition => "MessageDefinition",
             _ => throw new ArgumentOutOfRangeException(nameof(entityType), entityType, null)
         };
     }

--- a/src/ByteSync.ServerCommon/Interfaces/Loaders/IMessageDefinitionsLoader.cs
+++ b/src/ByteSync.ServerCommon/Interfaces/Loaders/IMessageDefinitionsLoader.cs
@@ -1,0 +1,8 @@
+using ByteSync.ServerCommon.Business.Messages;
+
+namespace ByteSync.ServerCommon.Interfaces.Loaders;
+
+public interface IMessageDefinitionsLoader
+{
+    Task<List<MessageDefinition>> Load();
+}

--- a/src/ByteSync.ServerCommon/Interfaces/Repositories/IMessageDefinitionRepository.cs
+++ b/src/ByteSync.ServerCommon/Interfaces/Repositories/IMessageDefinitionRepository.cs
@@ -1,0 +1,10 @@
+using ByteSync.ServerCommon.Business.Messages;
+
+namespace ByteSync.ServerCommon.Interfaces.Repositories;
+
+public interface IMessageDefinitionRepository : IRepository<List<MessageDefinition>>
+{
+    Task<List<MessageDefinition>?> GetAll();
+
+    Task SaveAll(List<MessageDefinition> definitions);
+}

--- a/src/ByteSync.ServerCommon/Loaders/ClientSoftwareVersionSettingsLoader.cs
+++ b/src/ByteSync.ServerCommon/Loaders/ClientSoftwareVersionSettingsLoader.cs
@@ -12,11 +12,16 @@ public class ClientSoftwareVersionSettingsLoader : IClientSoftwareVersionSetting
 {
     private readonly AppSettings _appSettings;
     private readonly ILogger<ClientSoftwareVersionSettingsLoader> _logger;
+    private readonly HttpClient _httpClient;
 
-    public ClientSoftwareVersionSettingsLoader(IOptions<AppSettings> appSettings, ILogger<ClientSoftwareVersionSettingsLoader> logger)
+    public ClientSoftwareVersionSettingsLoader(
+        IOptions<AppSettings> appSettings, 
+        ILogger<ClientSoftwareVersionSettingsLoader> logger,
+        HttpClient httpClient)
     {
         _appSettings = appSettings.Value;
         _logger = logger;
+        _httpClient = httpClient;
     }
 
     public async Task<ClientSoftwareVersionSettings> Load()
@@ -29,12 +34,8 @@ public class ClientSoftwareVersionSettingsLoader : IClientSoftwareVersionSetting
             
         await policy.Execute(async () =>
         {
-            string contents;
-            using (var wc = new HttpClient())
-            {
-                _logger.LogInformation("Loading minimal version from {url}", _appSettings.UpdatesDefinitionUrl);
-                contents = await wc.GetStringAsync(_appSettings.UpdatesDefinitionUrl);
-            }
+            _logger.LogInformation("Loading minimal version from {url}", _appSettings.UpdatesDefinitionUrl);
+            var contents = await _httpClient.GetStringAsync(_appSettings.UpdatesDefinitionUrl);
             
             var softwareUpdates = JsonHelper.Deserialize<List<SoftwareVersion>>(contents)!;
 

--- a/src/ByteSync.ServerCommon/Loaders/MessageDefinitionsLoader.cs
+++ b/src/ByteSync.ServerCommon/Loaders/MessageDefinitionsLoader.cs
@@ -1,0 +1,47 @@
+using ByteSync.Common.Controls.Json;
+using ByteSync.ServerCommon.Business.Messages;
+using ByteSync.ServerCommon.Business.Settings;
+using ByteSync.ServerCommon.Interfaces.Loaders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Polly;
+
+namespace ByteSync.ServerCommon.Loaders;
+
+public class MessageDefinitionsLoader : IMessageDefinitionsLoader
+{
+    private readonly AppSettings _appSettings;
+    private readonly ILogger<MessageDefinitionsLoader> _logger;
+
+    public MessageDefinitionsLoader(IOptions<AppSettings> appSettings, ILogger<MessageDefinitionsLoader> logger)
+    {
+        _appSettings = appSettings.Value;
+        _logger = logger;
+    }
+
+    public async Task<List<MessageDefinition>> Load()
+    {
+        List<MessageDefinition>? definitions = null;
+
+        var policy = Policy
+            .Handle<Exception>()
+            .WaitAndRetry(3, retryAttempt => TimeSpan.FromSeconds(3 * (retryAttempt + 1)));
+
+        await policy.Execute(async () =>
+        {
+            string contents;
+            using var httpClient = new HttpClient();
+            _logger.LogInformation("Loading messages from {url}", _appSettings.MessagesDefinitionsUrl);
+            contents = await httpClient.GetStringAsync(_appSettings.MessagesDefinitionsUrl);
+
+            definitions = JsonHelper.Deserialize<List<MessageDefinition>>(contents);
+        });
+
+        if (definitions == null)
+        {
+            throw new Exception("Failed to load messages");
+        }
+
+        return definitions!;
+    }
+}

--- a/src/ByteSync.ServerCommon/Loaders/MessageDefinitionsLoader.cs
+++ b/src/ByteSync.ServerCommon/Loaders/MessageDefinitionsLoader.cs
@@ -12,11 +12,16 @@ public class MessageDefinitionsLoader : IMessageDefinitionsLoader
 {
     private readonly AppSettings _appSettings;
     private readonly ILogger<MessageDefinitionsLoader> _logger;
+    private readonly HttpClient _httpClient;
 
-    public MessageDefinitionsLoader(IOptions<AppSettings> appSettings, ILogger<MessageDefinitionsLoader> logger)
+    public MessageDefinitionsLoader(
+        IOptions<AppSettings> appSettings, 
+        ILogger<MessageDefinitionsLoader> logger,
+        HttpClient httpClient)
     {
         _appSettings = appSettings.Value;
         _logger = logger;
+        _httpClient = httpClient;
     }
 
     public async Task<List<MessageDefinition>> Load()
@@ -29,10 +34,8 @@ public class MessageDefinitionsLoader : IMessageDefinitionsLoader
 
         await policy.Execute(async () =>
         {
-            string contents;
-            using var httpClient = new HttpClient();
             _logger.LogInformation("Loading messages from {url}", _appSettings.MessagesDefinitionsUrl);
-            contents = await httpClient.GetStringAsync(_appSettings.MessagesDefinitionsUrl);
+            var contents = await _httpClient.GetStringAsync(_appSettings.MessagesDefinitionsUrl);
 
             messageDefinitions = JsonHelper.Deserialize<List<MessageDefinition>>(contents);
         });

--- a/src/ByteSync.ServerCommon/Loaders/MessageDefinitionsLoader.cs
+++ b/src/ByteSync.ServerCommon/Loaders/MessageDefinitionsLoader.cs
@@ -21,7 +21,7 @@ public class MessageDefinitionsLoader : IMessageDefinitionsLoader
 
     public async Task<List<MessageDefinition>> Load()
     {
-        List<MessageDefinition>? definitions = null;
+        List<MessageDefinition>? messageDefinitions = null;
 
         var policy = Policy
             .Handle<Exception>()
@@ -34,14 +34,14 @@ public class MessageDefinitionsLoader : IMessageDefinitionsLoader
             _logger.LogInformation("Loading messages from {url}", _appSettings.MessagesDefinitionsUrl);
             contents = await httpClient.GetStringAsync(_appSettings.MessagesDefinitionsUrl);
 
-            definitions = JsonHelper.Deserialize<List<MessageDefinition>>(contents);
+            messageDefinitions = JsonHelper.Deserialize<List<MessageDefinition>>(contents);
         });
 
-        if (definitions == null)
+        if (messageDefinitions == null)
         {
             throw new Exception("Failed to load messages");
         }
 
-        return definitions!;
+        return messageDefinitions!;
     }
 }

--- a/src/ByteSync.ServerCommon/Repositories/MessageDefinitionRepository.cs
+++ b/src/ByteSync.ServerCommon/Repositories/MessageDefinitionRepository.cs
@@ -1,0 +1,28 @@
+using ByteSync.ServerCommon.Business.Messages;
+using ByteSync.ServerCommon.Entities;
+using ByteSync.ServerCommon.Interfaces.Repositories;
+using ByteSync.ServerCommon.Interfaces.Services;
+
+namespace ByteSync.ServerCommon.Repositories;
+
+public class MessageDefinitionRepository : BaseRepository<List<MessageDefinition>>, IMessageDefinitionRepository
+{
+    public const string UniqueKey = "All";
+
+    public MessageDefinitionRepository(IRedisInfrastructureService redisInfrastructureService, ICacheRepository<List<MessageDefinition>> cacheRepository)
+        : base(redisInfrastructureService, cacheRepository)
+    {
+    }
+
+    public override EntityType EntityType => EntityType.MessageDefinition;
+
+    public Task<List<MessageDefinition>?> GetAll()
+    {
+        return Get(UniqueKey);
+    }
+
+    public Task SaveAll(List<MessageDefinition> definitions)
+    {
+        return Save(UniqueKey, definitions);
+    }
+}

--- a/tests/ByteSync.Functions.UnitTests/Timer/RefreshMessageDefinitionsFunctionTests.cs
+++ b/tests/ByteSync.Functions.UnitTests/Timer/RefreshMessageDefinitionsFunctionTests.cs
@@ -1,0 +1,47 @@
+using ByteSync.Functions.Timer;
+using ByteSync.ServerCommon.Business.Messages;
+using ByteSync.ServerCommon.Interfaces.Loaders;
+using ByteSync.ServerCommon.Interfaces.Repositories;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ByteSync.Functions.UnitTests.Timer;
+
+[TestFixture]
+public class RefreshMessageDefinitionsFunctionTests
+{
+    private Mock<IMessageDefinitionsLoader> _loader = null!;
+    private Mock<IMessageDefinitionRepository> _repository = null!;
+    private Mock<ILogger<RefreshMessageDefinitionsFunction>> _logger = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _loader = new Mock<IMessageDefinitionsLoader>();
+        _repository = new Mock<IMessageDefinitionRepository>();
+        _logger = new Mock<ILogger<RefreshMessageDefinitionsFunction>>();
+    }
+
+    [Test]
+    public async Task RunAsync_ShouldFilterExpiredMessages()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var messages = new List<MessageDefinition>
+        {
+            new MessageDefinition { StartDate = now.AddHours(-1), EndDate = now.AddHours(1), Message = new Dictionary<string,string>{{"en","valid"}} },
+            new MessageDefinition { StartDate = now.AddHours(-2), EndDate = now.AddHours(-1), Message = new Dictionary<string,string>{{"en","expired"}} }
+        };
+        _loader.Setup(l => l.Load()).ReturnsAsync(messages);
+        var function = new RefreshMessageDefinitionsFunction(_loader.Object, _repository.Object, _logger.Object);
+
+        // Act
+        var result = await function.RunAsync(new TimerInfo());
+
+        // Assert
+        _loader.Verify(l => l.Load(), Times.Once);
+        _repository.Verify(r => r.SaveAll(It.Is<List<MessageDefinition>>(l => l.Count == 1 && l[0].Message["en"] == "valid")), Times.Once);
+        Assert.That(result, Is.EqualTo(1));
+    }
+}

--- a/tests/ByteSync.Functions.UnitTests/Timer/RefreshMessageDefinitionsFunctionTests.cs
+++ b/tests/ByteSync.Functions.UnitTests/Timer/RefreshMessageDefinitionsFunctionTests.cs
@@ -30,8 +30,8 @@ public class RefreshMessageDefinitionsFunctionTests
         var now = DateTime.UtcNow;
         var messages = new List<MessageDefinition>
         {
-            new MessageDefinition { StartDate = now.AddHours(-1), EndDate = now.AddHours(1), Message = new Dictionary<string,string>{{"en","valid"}} },
-            new MessageDefinition { StartDate = now.AddHours(-2), EndDate = now.AddHours(-1), Message = new Dictionary<string,string>{{"en","expired"}} }
+            new MessageDefinition { Id = Guid.NewGuid().ToString("D"), StartDate = now.AddHours(-1), EndDate = now.AddHours(1), Message = new Dictionary<string,string>{{"en","valid"}} },
+            new MessageDefinition { Id = Guid.NewGuid().ToString("D"), StartDate = now.AddHours(-2), EndDate = now.AddHours(-1), Message = new Dictionary<string,string>{{"en","expired"}} }
         };
         _loader.Setup(l => l.Load()).ReturnsAsync(messages);
         var function = new RefreshMessageDefinitionsFunction(_loader.Object, _repository.Object, _logger.Object);

--- a/tests/ByteSync.ServerCommon.Tests/Factories/CacheKeyFactoryTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Factories/CacheKeyFactoryTests.cs
@@ -33,6 +33,7 @@ public class CacheKeyFactoryTests
     [TestCase(EntityType.ClientSoftwareVersionSettings, "version123", "ClientSoftwareVersionSettings")]
     [TestCase(EntityType.CloudSessionProfile, "profile123", "CloudSessionProfile")]
     [TestCase(EntityType.Lobby, "lobby123", "Lobby")]
+    [TestCase(EntityType.MessageDefinition, "msg123", "MessageDefinition")]
     public void Create_ShouldGenerateCacheKey_WithCorrectFormat(EntityType entityType, string entityId, string expectedEntityTypeName)
     {
         // Arrange

--- a/tests/ByteSync.ServerCommon.Tests/Helpers/MockHttpMessageHandler.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Helpers/MockHttpMessageHandler.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Text;
+
+namespace ByteSync.ServerCommon.Tests.Helpers;
+
+public class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _responseContent;
+    private readonly HttpStatusCode _statusCode;
+
+    public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _responseContent = responseContent;
+        _statusCode = statusCode;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
+        };
+
+        return Task.FromResult(response);
+    }
+} 

--- a/tests/ByteSync.ServerCommon.Tests/Loaders/ClientSoftwareVersionSettingsLoaderTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Loaders/ClientSoftwareVersionSettingsLoaderTests.cs
@@ -1,14 +1,13 @@
 using ByteSync.Common.Business.Versions;
 using ByteSync.Common.Controls.Json;
 using ByteSync.ServerCommon.Business.Settings;
-using ByteSync.ServerCommon.Interfaces.Loaders;
 using ByteSync.ServerCommon.Loaders;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Net;
-using System.Text;
+using ByteSync.ServerCommon.Tests.Helpers;
 
 namespace ByteSync.ServerCommon.Tests.Loaders;
 

--- a/tests/ByteSync.ServerCommon.Tests/Loaders/ClientSoftwareVersionSettingsLoaderTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Loaders/ClientSoftwareVersionSettingsLoaderTests.cs
@@ -1,0 +1,182 @@
+using ByteSync.Common.Business.Versions;
+using ByteSync.Common.Controls.Json;
+using ByteSync.ServerCommon.Business.Settings;
+using ByteSync.ServerCommon.Interfaces.Loaders;
+using ByteSync.ServerCommon.Loaders;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Text;
+
+namespace ByteSync.ServerCommon.Tests.Loaders;
+
+[TestFixture]
+public class ClientSoftwareVersionSettingsLoaderTests
+{
+    private ILogger<ClientSoftwareVersionSettingsLoader> _mockLogger;
+    private IOptions<AppSettings> _mockAppSettings;
+    private HttpClient _httpClient;
+    private ClientSoftwareVersionSettingsLoader _loader;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockLogger = A.Fake<ILogger<ClientSoftwareVersionSettingsLoader>>();
+        _mockAppSettings = Options.Create(new AppSettings 
+        { 
+            UpdatesDefinitionUrl = "https://test.example.com/updates.json" 
+        });
+        _httpClient = new HttpClient(new MockHttpMessageHandler(""));
+        _loader = new ClientSoftwareVersionSettingsLoader(_mockAppSettings, _mockLogger, _httpClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient?.Dispose();
+    }
+
+    [Test]
+    public async Task Load_ShouldReturnClientSoftwareVersionSettings_WhenValidDataIsRetrieved()
+    {
+        // Arrange
+        var softwareVersions = new List<SoftwareVersion>
+        {
+            new SoftwareVersion 
+            { 
+                ProductCode = "ByteSync", 
+                Version = "1.0.0", 
+                Level = PriorityLevel.Minimal 
+            },
+            new SoftwareVersion 
+            { 
+                ProductCode = "ByteSync", 
+                Version = "1.1.0", 
+                Level = PriorityLevel.Recommended 
+            }
+        };
+
+        var jsonContent = JsonHelper.Serialize(softwareVersions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new ClientSoftwareVersionSettingsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act
+        var result = await _loader.Load();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.MinimalVersion.Should().NotBeNull();
+        result.MinimalVersion!.Version.Should().Be("1.0.0");
+        result.MinimalVersion.Level.Should().Be(PriorityLevel.Minimal);
+        result.MinimalVersion.ProductCode.Should().Be("ByteSync");
+    }
+
+    [Test]
+    public async Task Load_ShouldThrowException_WhenNoMinimalVersionFound()
+    {
+        // Arrange
+        var softwareVersions = new List<SoftwareVersion>
+        {
+            new SoftwareVersion 
+            { 
+                ProductCode = "ByteSync", 
+                Version = "1.1.0", 
+                Level = PriorityLevel.Recommended 
+            },
+            new SoftwareVersion 
+            { 
+                ProductCode = "ByteSync", 
+                Version = "1.2.0", 
+                Level = PriorityLevel.Optional 
+            }
+        };
+
+        var jsonContent = JsonHelper.Serialize(softwareVersions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new ClientSoftwareVersionSettingsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act & Assert
+        var exception = await FluentActions.Awaiting(() => _loader.Load())
+            .Should().ThrowAsync<Exception>();
+        exception.WithMessage("Failed to load minimal version");
+    }
+
+    [Test]
+    public async Task Load_ShouldThrowException_WhenHttpRequestFails()
+    {
+        // Arrange
+        _httpClient = new HttpClient(new MockHttpMessageHandler("", HttpStatusCode.NotFound));
+        _loader = new ClientSoftwareVersionSettingsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act & Assert
+        await FluentActions.Awaiting(() => _loader.Load())
+            .Should().ThrowAsync<Exception>();
+    }
+
+    [Test]
+    public async Task Load_ShouldHandleEmptyList_AndThrowException()
+    {
+        // Arrange
+        var softwareVersions = new List<SoftwareVersion>();
+        var jsonContent = JsonHelper.Serialize(softwareVersions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new ClientSoftwareVersionSettingsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act & Assert
+        var exception = await FluentActions.Awaiting(() => _loader.Load())
+            .Should().ThrowAsync<Exception>();
+        exception.WithMessage("Failed to load minimal version");
+    }
+
+    [Test]
+    public async Task Load_ShouldHandleNullList_AndThrowException()
+    {
+        // Arrange
+        List<SoftwareVersion>? softwareVersions = null;
+        var jsonContent = JsonHelper.Serialize(softwareVersions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new ClientSoftwareVersionSettingsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act & Assert
+        var exception = await FluentActions.Awaiting(() => _loader.Load())
+            .Should().ThrowAsync<Exception>();
+        exception.WithMessage("Failed to deserialize JSON.");
+    }
+
+    [Test]
+    public async Task Load_ShouldHandleMalformedJson_AndThrowException()
+    {
+        // Arrange
+        var malformedJson = "{ invalid json }";
+        _httpClient = new HttpClient(new MockHttpMessageHandler(malformedJson));
+        _loader = new ClientSoftwareVersionSettingsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act & Assert
+        await FluentActions.Awaiting(() => _loader.Load())
+            .Should().ThrowAsync<Exception>();
+    }
+}
+
+// public class MockHttpMessageHandler : HttpMessageHandler
+// {
+//     private readonly string _responseContent;
+//     private readonly HttpStatusCode _statusCode;
+//
+//     public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+//     {
+//         _responseContent = responseContent;
+//         _statusCode = statusCode;
+//     }
+//
+//     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+//     {
+//         var response = new HttpResponseMessage(_statusCode)
+//         {
+//             Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
+//         };
+//
+//         return Task.FromResult(response);
+//     }
+// } 

--- a/tests/ByteSync.ServerCommon.Tests/Loaders/ClientSoftwareVersionSettingsLoaderTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Loaders/ClientSoftwareVersionSettingsLoaderTests.cs
@@ -158,25 +158,3 @@ public class ClientSoftwareVersionSettingsLoaderTests
             .Should().ThrowAsync<Exception>();
     }
 }
-
-// public class MockHttpMessageHandler : HttpMessageHandler
-// {
-//     private readonly string _responseContent;
-//     private readonly HttpStatusCode _statusCode;
-//
-//     public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
-//     {
-//         _responseContent = responseContent;
-//         _statusCode = statusCode;
-//     }
-//
-//     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-//     {
-//         var response = new HttpResponseMessage(_statusCode)
-//         {
-//             Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
-//         };
-//
-//         return Task.FromResult(response);
-//     }
-// } 

--- a/tests/ByteSync.ServerCommon.Tests/Loaders/MessageDefinitionsLoaderTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Loaders/MessageDefinitionsLoaderTests.cs
@@ -1,7 +1,6 @@
 using ByteSync.Common.Controls.Json;
 using ByteSync.ServerCommon.Business.Messages;
 using ByteSync.ServerCommon.Business.Settings;
-using ByteSync.ServerCommon.Interfaces.Loaders;
 using ByteSync.ServerCommon.Loaders;
 using FakeItEasy;
 using FluentAssertions;
@@ -9,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Net;
 using System.Text;
-using Moq;
+using ByteSync.ServerCommon.Tests.Helpers;
 
 namespace ByteSync.ServerCommon.Tests.Loaders;
 
@@ -184,25 +183,3 @@ public class MessageDefinitionsLoaderTests
         result[0].Id.Should().Be("msg1");
     }
 }
-
-public class MockHttpMessageHandler : HttpMessageHandler
-{
-    private readonly string _responseContent;
-    private readonly HttpStatusCode _statusCode;
-
-    public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
-    {
-        _responseContent = responseContent;
-        _statusCode = statusCode;
-    }
-
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        var response = new HttpResponseMessage(_statusCode)
-        {
-            Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
-        };
-
-        return Task.FromResult(response);
-    }
-} 

--- a/tests/ByteSync.ServerCommon.Tests/Loaders/MessageDefinitionsLoaderTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Loaders/MessageDefinitionsLoaderTests.cs
@@ -1,0 +1,208 @@
+using ByteSync.Common.Controls.Json;
+using ByteSync.ServerCommon.Business.Messages;
+using ByteSync.ServerCommon.Business.Settings;
+using ByteSync.ServerCommon.Interfaces.Loaders;
+using ByteSync.ServerCommon.Loaders;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Text;
+using Moq;
+
+namespace ByteSync.ServerCommon.Tests.Loaders;
+
+[TestFixture]
+public class MessageDefinitionsLoaderTests
+{
+    private ILogger<MessageDefinitionsLoader> _mockLogger;
+    private IOptions<AppSettings> _mockAppSettings;
+    private HttpClient _httpClient;
+    private MessageDefinitionsLoader _loader;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockLogger = A.Fake<ILogger<MessageDefinitionsLoader>>();
+        _mockAppSettings = Options.Create(new AppSettings 
+        { 
+            MessagesDefinitionsUrl = "https://test.example.com/messages.json" 
+        });
+        _httpClient = new HttpClient(new MockHttpMessageHandler(""));
+        _loader = new MessageDefinitionsLoader(_mockAppSettings, _mockLogger, _httpClient);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient?.Dispose();
+    }
+
+    [Test]
+    public async Task Load_ShouldReturnMessageDefinitions_WhenValidDataIsRetrieved()
+    {
+        // Arrange
+        var messageDefinitions = new List<MessageDefinition>
+        {
+            new MessageDefinition
+            {
+                Id = "msg1",
+                StartDate = DateTime.UtcNow.AddDays(-1),
+                EndDate = DateTime.UtcNow.AddDays(1),
+                Message = new Dictionary<string, string>
+                {
+                    { "en", "Test message in English" },
+                    { "fr", "Message de test en français" }
+                }
+            },
+            new MessageDefinition
+            {
+                Id = "msg2",
+                StartDate = DateTime.UtcNow,
+                EndDate = DateTime.UtcNow.AddDays(7),
+                Message = new Dictionary<string, string>
+                {
+                    { "en", "Another test message" },
+                    { "fr", "Un autre message de test" }
+                }
+            }
+        };
+
+        var jsonContent = JsonHelper.Serialize(messageDefinitions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new MessageDefinitionsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act
+        var result = await _loader.Load();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(2);
+        result[0].Id.Should().Be("msg1");
+        result[0].Message["en"].Should().Be("Test message in English");
+        result[0].Message["fr"].Should().Be("Message de test en français");
+        result[1].Id.Should().Be("msg2");
+    }
+
+    [Test]
+    public async Task Load_ShouldThrowException_WhenHttpRequestFails()
+    {
+        // Arrange
+        _httpClient = new HttpClient(new MockHttpMessageHandler("", HttpStatusCode.NotFound));
+        _loader = new MessageDefinitionsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act & Assert
+        await FluentActions.Awaiting(() => _loader.Load())
+            .Should().ThrowAsync<Exception>();
+    }
+
+    [Test]
+    public async Task Load_ShouldHandleEmptyList_AndReturnEmptyList()
+    {
+        // Arrange
+        var messageDefinitions = new List<MessageDefinition>();
+        var jsonContent = JsonHelper.Serialize(messageDefinitions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new MessageDefinitionsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act
+        var result = await _loader.Load();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Load_ShouldThrowException_WhenDeserializationReturnsNull()
+    {
+        // Arrange
+        var malformedJson = "{ invalid json }";
+        _httpClient = new HttpClient(new MockHttpMessageHandler(malformedJson));
+        _loader = new MessageDefinitionsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act & Assert
+        await FluentActions.Awaiting(() => _loader.Load())
+            .Should().ThrowAsync<Exception>();
+    }
+
+    [Test]
+    public async Task Load_ShouldHandleMessageDefinitionsWithEmptyMessages()
+    {
+        // Arrange
+        var messageDefinitions = new List<MessageDefinition>
+        {
+            new MessageDefinition
+            {
+                Id = "msg1",
+                StartDate = DateTime.UtcNow.AddDays(-1),
+                EndDate = DateTime.UtcNow.AddDays(1),
+                Message = new Dictionary<string, string>() // Empty messages
+            }
+        };
+
+        var jsonContent = JsonHelper.Serialize(messageDefinitions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new MessageDefinitionsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act
+        var result = await _loader.Load();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        result[0].Id.Should().Be("msg1");
+        result[0].Message.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Load_ShouldHandleMessageDefinitionsWithNullMessages()
+    {
+        // Arrange
+        var messageDefinitions = new List<MessageDefinition>
+        {
+            new MessageDefinition
+            {
+                Id = "msg1",
+                StartDate = DateTime.UtcNow.AddDays(-1),
+                EndDate = DateTime.UtcNow.AddDays(1),
+                Message = null! // Null messages
+            }
+        };
+
+        var jsonContent = JsonHelper.Serialize(messageDefinitions);
+        _httpClient = new HttpClient(new MockHttpMessageHandler(jsonContent));
+        _loader = new MessageDefinitionsLoader(_mockAppSettings, _mockLogger, _httpClient);
+
+        // Act
+        var result = await _loader.Load();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        result[0].Id.Should().Be("msg1");
+    }
+}
+
+public class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _responseContent;
+    private readonly HttpStatusCode _statusCode;
+
+    public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        _responseContent = responseContent;
+        _statusCode = statusCode;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
+        };
+
+        return Task.FromResult(response);
+    }
+} 


### PR DESCRIPTION
## Summary
- load info messages from MessagesDefinitionsUrl
- cache these message definitions in Redis
- refresh messages every 2 hours via new timer function
- document MessagesDefinitionsUrl in deployment guides
- include messages URL in client settings template
- test timer refresh logic
- update cache key logic for new entity type

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686893f51bf8833387cff5ef990bdf69