### PR TITLE
[feature] Add messages API

### DIFF
--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -154,6 +154,13 @@ Repeat these steps for **ByteSync.Functions.IntegrationTests** and **ByteSync.Se
 
 ---
 
+### Messages API
+
+The function app exposes a `GET /api/messages` endpoint that returns the currently active messages.
+Each item includes `id`, `startDate`, `endDate` and a language dictionary `message`.
+
+---
+
 ## Final Steps
 
 1. **Deploy** your Azure Function (Windows) to Azure.

--- a/src/ByteSync.Functions/Http/MessageDefinitionFunction.cs
+++ b/src/ByteSync.Functions/Http/MessageDefinitionFunction.cs
@@ -1,0 +1,29 @@
+using System.Net;
+using ByteSync.ServerCommon.Commands.Messages;
+using MediatR;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace ByteSync.Functions.Http;
+
+public class MessageDefinitionFunction
+{
+    private readonly IMediator _mediator;
+
+    public MessageDefinitionFunction(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [Function("GetMessages")]
+    public async Task<HttpResponseData> GetMessages(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "messages")] HttpRequestData req,
+        FunctionContext executionContext)
+    {
+        var messages = await _mediator.Send(new GetActiveMessagesRequest());
+
+        var response = req.CreateResponse();
+        await response.WriteAsJsonAsync(messages, HttpStatusCode.OK);
+        return response;
+    }
+}

--- a/src/ByteSync.ServerCommon/Commands/Messages/GetActiveMessagesCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Messages/GetActiveMessagesCommandHandler.cs
@@ -1,0 +1,27 @@
+using ByteSync.ServerCommon.Business.Messages;
+using ByteSync.ServerCommon.Interfaces.Repositories;
+using MediatR;
+
+namespace ByteSync.ServerCommon.Commands.Messages;
+
+public class GetActiveMessagesCommandHandler : IRequestHandler<GetActiveMessagesRequest, List<MessageDefinition>>
+{
+    private readonly IMessageDefinitionRepository _repository;
+
+    public GetActiveMessagesCommandHandler(IMessageDefinitionRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<List<MessageDefinition>> Handle(GetActiveMessagesRequest request, CancellationToken cancellationToken)
+    {
+        var allMessages = await _repository.GetAll();
+        if (allMessages is null)
+        {
+            return new List<MessageDefinition>();
+        }
+
+        var now = DateTime.UtcNow;
+        return allMessages.Where(m => m.StartDate <= now && now < m.EndDate).ToList();
+    }
+}

--- a/src/ByteSync.ServerCommon/Commands/Messages/GetActiveMessagesRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Messages/GetActiveMessagesRequest.cs
@@ -1,0 +1,6 @@
+using ByteSync.ServerCommon.Business.Messages;
+using MediatR;
+
+namespace ByteSync.ServerCommon.Commands.Messages;
+
+public class GetActiveMessagesRequest : IRequest<List<MessageDefinition>>;

--- a/tests/ByteSync.ServerCommon.Tests/Commands/Messages/GetActiveMessagesCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/Messages/GetActiveMessagesCommandHandlerTests.cs
@@ -1,0 +1,43 @@
+using ByteSync.ServerCommon.Business.Messages;
+using ByteSync.ServerCommon.Commands.Messages;
+using ByteSync.ServerCommon.Interfaces.Repositories;
+using FakeItEasy;
+using FluentAssertions;
+
+namespace ByteSync.ServerCommon.Tests.Commands.Messages;
+
+[TestFixture]
+public class GetActiveMessagesCommandHandlerTests
+{
+    private IMessageDefinitionRepository _repository = null!;
+    private GetActiveMessagesCommandHandler _handler = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _repository = A.Fake<IMessageDefinitionRepository>();
+        _handler = new GetActiveMessagesCommandHandler(_repository);
+    }
+
+    [Test]
+    public async Task Handle_ReturnsOnlyActiveMessages()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var messages = new List<MessageDefinition>
+        {
+            new() { Id = "1", StartDate = now.AddHours(-1), EndDate = now.AddHours(1) },
+            new() { Id = "2", StartDate = now.AddHours(-2), EndDate = now.AddHours(-1) },
+            new() { Id = "3", StartDate = now.AddHours(1), EndDate = now.AddHours(2) }
+        };
+        A.CallTo(() => _repository.GetAll()).Returns(messages);
+
+        // Act
+        var result = await _handler.Handle(new GetActiveMessagesRequest(), CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].Id.Should().Be("1");
+        A.CallTo(() => _repository.GetAll()).MustHaveHappenedOnceExactly();
+    }
+}


### PR DESCRIPTION
## Summary
- implement GetActiveMessages request/handler
- expose GetMessages HTTP function
- test message filtering
- document `/messages` endpoint

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab3620b28833393d9e511b52bf862