### PR TITLE
[feature] Add announcement API client

### DIFF
--- a/src/ByteSync.Client/Interfaces/Controls/Communications/Http/IAnnouncementApiClient.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/Http/IAnnouncementApiClient.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ByteSync.Common.Business.Announcements;
+
+namespace ByteSync.Interfaces.Controls.Communications.Http;
+
+public interface IAnnouncementApiClient
+{
+    Task<List<Announcement>> GetAnnouncements();
+}

--- a/src/ByteSync.Client/Services/Communications/Api/AnnouncementApiClient.cs
+++ b/src/ByteSync.Client/Services/Communications/Api/AnnouncementApiClient.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ByteSync.Common.Business.Announcements;
+using ByteSync.Interfaces.Controls.Communications.Http;
+
+namespace ByteSync.Services.Communications.Api;
+
+public class AnnouncementApiClient : IAnnouncementApiClient
+{
+    private readonly IApiInvoker _apiInvoker;
+    private readonly ILogger<AnnouncementApiClient> _logger;
+
+    public AnnouncementApiClient(IApiInvoker apiInvoker, ILogger<AnnouncementApiClient> logger)
+    {
+        _apiInvoker = apiInvoker;
+        _logger = logger;
+    }
+
+    public async Task<List<Announcement>> GetAnnouncements()
+    {
+        try
+        {
+            return await _apiInvoker.GetAsync<List<Announcement>>("announcements");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error while retrieving announcements");
+            throw;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `IAnnouncementApiClient` interface
- implement `AnnouncementApiClient` using `IApiInvoker`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad914c54883339aa4c7efeabced4f