### PR TITLE
[feature] Implement announcement refresh service

### DIFF
--- a/src/ByteSync.Client/Interfaces/Announcements/IAnnouncementService.cs
+++ b/src/ByteSync.Client/Interfaces/Announcements/IAnnouncementService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace ByteSync.Interfaces.Announcements;
+
+public interface IAnnouncementService
+{
+    Task Start();
+}

--- a/src/ByteSync.Client/Services/Announcements/AnnouncementService.cs
+++ b/src/ByteSync.Client/Services/Announcements/AnnouncementService.cs
@@ -1,0 +1,78 @@
+using ByteSync.Interfaces.Announcements;
+using ByteSync.Interfaces.Controls.Communications.Http;
+using ByteSync.Interfaces.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace ByteSync.Services.Announcements;
+
+public class AnnouncementService : IAnnouncementService, IDisposable
+{
+    private readonly IAnnouncementApiClient _apiClient;
+    private readonly IAnnouncementRepository _repository;
+    private readonly ILogger<AnnouncementService> _logger;
+    private CancellationTokenSource? _refreshCancellationTokenSource;
+
+    public AnnouncementService(IAnnouncementApiClient apiClient, IAnnouncementRepository repository,
+        ILogger<AnnouncementService> logger)
+    {
+        _apiClient = apiClient;
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task Start()
+    {
+        await RefreshAnnouncements();
+
+        _refreshCancellationTokenSource = new CancellationTokenSource();
+        var token = _refreshCancellationTokenSource.Token;
+
+        _ = Task.Run(async () =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromHours(2), token);
+                    if (token.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    await RefreshAnnouncements();
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error while refreshing announcements");
+                }
+            }
+        }, token);
+    }
+
+    private async Task RefreshAnnouncements()
+    {
+        try
+        {
+            var announcements = await _apiClient.GetAnnouncements();
+            _repository.Clear();
+            _repository.AddOrUpdate(announcements);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error while loading announcements");
+        }
+    }
+
+    public void Dispose()
+    {
+        var cts = _refreshCancellationTokenSource;
+        if (cts != null)
+        {
+            cts.Cancel();
+            cts.Dispose();
+        }
+    }
+}

--- a/src/ByteSync.Client/Services/Announcements/AnnouncementService.cs
+++ b/src/ByteSync.Client/Services/Announcements/AnnouncementService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using ByteSync.Interfaces.Announcements;
 using ByteSync.Interfaces.Controls.Communications.Http;
 using ByteSync.Interfaces.Repositories;


### PR DESCRIPTION
## Summary
- define `IAnnouncementService`
- add `AnnouncementService` to fetch and update announcements periodically

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adb592c808333bcc39be7a3e0573e