### PR TITLE
Fix InventoryBuilderFactory

### DIFF
--- a/src/ByteSync.Client/Factories/InventoryBuilderFactory.cs
+++ b/src/ByteSync.Client/Factories/InventoryBuilderFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using ByteSync.Business;
+using ByteSync.Business.DataNodes;
 using ByteSync.Business.Inventories;
 using ByteSync.Business.SessionMembers;
 using ByteSync.Business.Sessions;
@@ -28,13 +29,16 @@ public class InventoryBuilderFactory : IInventoryBuilderFactory
         var inventoryService = _context.Resolve<IInventoryService>();
         var environmentService = _context.Resolve<IEnvironmentService>();
         var dataSourceRepository = _context.Resolve<IDataSourceRepository>();
+        var dataNodeRepository = _context.Resolve<IDataNodeRepository>();
         
         var sessionMember = sessionMemberRepository.GetCurrentSessionMember();
         var cloudSessionSettings = sessionService.CurrentSessionSettings!;
         var myDataSources = dataSourceRepository.SortedCurrentMemberDataSources;
+        var myDataNode = dataNodeRepository.SortedCurrentMemberDataNodes.First();
         
         var inventoryBuilder = _context.Resolve<IInventoryBuilder>(
             new TypedParameter(typeof(SessionMember), sessionMember),
+            new TypedParameter(typeof(DataNode), myDataNode),
             new TypedParameter(typeof(SessionSettings), cloudSessionSettings),
             new TypedParameter(typeof(InventoryProcessData), inventoryService.InventoryProcessData),
             new TypedParameter(typeof(OSPlatforms), environmentService.OSPlatform),

--- a/tests/ByteSync.Client.IntegrationTests/Factories/TestInventoryBuilderFactory.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Factories/TestInventoryBuilderFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using ByteSync.Business.DataNodes;
 using ByteSync.Business.DataSources;
 using ByteSync.Business.Inventories;
 using ByteSync.Business.SessionMembers;
@@ -37,18 +38,21 @@ public class TestInventoryBuilderFactory : IntegrationTest
         var mockInventoryService = Container.Resolve<Mock<IInventoryService>>();
         var mockEnvironmentService = Container.Resolve<Mock<IEnvironmentService>>();
         var mockDataSourceRepository = Container.Resolve<Mock<IDataSourceRepository>>();
+        var mockDataNodeRepository = Container.Resolve<Mock<IDataNodeRepository>>();
         
         var fakeSessionMember = new SessionMember();
         var fakeSessionSettings = new SessionSettings();
         var fakeProcessData = new InventoryProcessData();
         var fakePlatform = OSPlatforms.Windows;
         var fakeDataSources = new List<DataSource> { Mock.Of<DataSource>(), Mock.Of<DataSource>() };
+        var fakeDataNdes = new List<DataNode> { Mock.Of<DataNode>() };
         
         mockSessionMemberRepo.Setup(r => r.GetCurrentSessionMember()).Returns(fakeSessionMember).Verifiable();
         mockSessionService.SetupGet(s => s.CurrentSessionSettings).Returns(fakeSessionSettings).Verifiable();
         mockInventoryService.SetupGet(s => s.InventoryProcessData).Returns(fakeProcessData).Verifiable();
         mockEnvironmentService.SetupGet(e => e.OSPlatform).Returns(fakePlatform).Verifiable();
         mockDataSourceRepository.SetupGet(r => r.SortedCurrentMemberDataSources).Returns(fakeDataSources).Verifiable();
+        mockDataNodeRepository.SetupGet(r => r.SortedCurrentMemberDataNodes).Returns(fakeDataNdes).Verifiable();
 
         // Act
         var inventoryBuilder = _inventoryBuilderFactor.CreateInventoryBuilder();


### PR DESCRIPTION
This pull request introduces support for `DataNode` objects in the inventory-building process, ensuring that both production and test code handle `DataNode` dependencies correctly. The changes include updates to the `InventoryBuilderFactory` implementation and its corresponding integration tests.

### Updates to InventoryBuilderFactory:

* [`src/ByteSync.Client/Factories/InventoryBuilderFactory.cs`](diffhunk://#diff-e7cfbb11c22d247d9e815c11e01f4a54a7cb43e389e1c28919d838bc62c6ce44R3): Added dependency resolution for `IDataNodeRepository` and incorporated `DataNode` as a parameter in the inventory builder creation process. [[1]](diffhunk://#diff-e7cfbb11c22d247d9e815c11e01f4a54a7cb43e389e1c28919d838bc62c6ce44R3) [[2]](diffhunk://#diff-e7cfbb11c22d247d9e815c11e01f4a54a7cb43e389e1c28919d838bc62c6ce44R32-R41)

### Updates to Integration Tests:

* [`tests/ByteSync.Client.IntegrationTests/Factories/TestInventoryBuilderFactory.cs`](diffhunk://#diff-c75ec17f852efa6f2e55dea64a699498984388d4347ca817a35d2c84fc9cfbafR2): Updated the test setup to include mocking for `IDataNodeRepository` and added `DataNode` objects to the test data to validate inventory builder functionality. [[1]](diffhunk://#diff-c75ec17f852efa6f2e55dea64a699498984388d4347ca817a35d2c84fc9cfbafR2) [[2]](diffhunk://#diff-c75ec17f852efa6f2e55dea64a699498984388d4347ca817a35d2c84fc9cfbafR41-R55)