### PR TITLE
Extract BlobStorage Container management

### DIFF
--- a/src/ByteSync.ServerCommon/Interfaces/Services/IBlobStorageContainerService.cs
+++ b/src/ByteSync.ServerCommon/Interfaces/Services/IBlobStorageContainerService.cs
@@ -1,0 +1,11 @@
+﻿using Azure.Storage;
+using Azure.Storage.Blobs;
+
+namespace ByteSync.ServerCommon.Interfaces.Services;
+
+public interface IBlobStorageContainerService
+{
+    Task<BlobContainerClient> BuildBlobContainerClient();
+    
+    StorageSharedKeyCredential StorageSharedKeyCredential { get; }
+}

--- a/src/ByteSync.ServerCommon/Services/BlobStorageContainerService.cs
+++ b/src/ByteSync.ServerCommon/Services/BlobStorageContainerService.cs
@@ -1,0 +1,59 @@
+﻿using Azure.Storage;
+using Azure.Storage.Blobs;
+using ByteSync.ServerCommon.Business.Settings;
+using ByteSync.ServerCommon.Interfaces.Services;
+using Microsoft.Extensions.Options;
+
+namespace ByteSync.ServerCommon.Services;
+
+public class BlobStorageContainerService : IBlobStorageContainerService
+{
+    private readonly BlobStorageSettings _blobStorageSettings;
+    
+    private StorageSharedKeyCredential? _storageSharedKeyCredential;
+
+    public BlobStorageContainerService(IOptions<BlobStorageSettings> blobStorageSettings)
+    {
+        _blobStorageSettings = blobStorageSettings.Value;
+    }
+    
+    public async Task<BlobContainerClient> BuildBlobContainerClient()
+    {
+        Uri containerUri = BuildContainerUri();
+        
+        var container = new BlobContainerClient(containerUri, StorageSharedKeyCredential);
+        
+        await container.CreateIfNotExistsAsync();
+
+        return container;
+    }
+
+    public StorageSharedKeyCredential StorageSharedKeyCredential
+    {
+        get
+        {
+            if (_storageSharedKeyCredential == null)
+            {
+                _storageSharedKeyCredential = BuildStorageSharedKeyCredential();
+            }
+            
+            return _storageSharedKeyCredential;
+        }
+    }
+
+    private Uri BuildContainerUri()
+    {
+        string endpoint = _blobStorageSettings.Endpoint.TrimEnd('/');
+        string container = _blobStorageSettings.Container.TrimStart('/').TrimEnd('/') + "/";
+
+        Uri baseUri = new Uri(endpoint);
+        Uri fullUri = new Uri(baseUri, container);
+
+        return fullUri;
+    }
+    
+    private StorageSharedKeyCredential BuildStorageSharedKeyCredential()
+    {
+        return new StorageSharedKeyCredential(_blobStorageSettings.AccountName, _blobStorageSettings.AccountKey);
+    }
+}

--- a/tests/ByteSync.ServerCommon.Tests/Services/BlobStorageContainerServiceTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Services/BlobStorageContainerServiceTests.cs
@@ -1,0 +1,52 @@
+using Azure.Storage;
+using ByteSync.ServerCommon.Business.Settings;
+using ByteSync.ServerCommon.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace ByteSync.ServerCommon.Tests.Services;
+
+[TestFixture]
+public class BlobStorageContainerServiceTests
+{
+    private BlobStorageSettings _settings;
+    private IOptions<BlobStorageSettings> _options;
+    private BlobStorageContainerService _service;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _settings = new BlobStorageSettings
+        {
+            AccountName = "testaccount",
+            AccountKey = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("testkey")),
+            Endpoint = "https://test.blob.core.windows.net/",
+            Container = "testcontainer"
+        };
+        _options = Options.Create(_settings);
+        _service = new BlobStorageContainerService(_options);
+    }
+
+    [Test]
+    public void StorageSharedKeyCredential_ShouldReturnValidCredential()
+    {
+        // Act
+        var credential = _service.StorageSharedKeyCredential;
+
+        // Assert
+        credential.Should().NotBeNull();
+        credential.AccountName.Should().Be(_settings.AccountName);
+        credential.Should().BeOfType<StorageSharedKeyCredential>();
+    }
+
+    [Test]
+    public void StorageSharedKeyCredential_ShouldBeSingleton()
+    {
+        // Act
+        var credential1 = _service.StorageSharedKeyCredential;
+        var credential2 = _service.StorageSharedKeyCredential;
+
+        // Assert
+        credential1.Should().BeSameAs(credential2);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new service, `BlobStorageContainerService`, to centralize blob storage container management and refactors the existing `BlobUrlService` to utilize this new service. Additionally, unit tests for the new service have been added to ensure proper functionality.

### New Service Implementation:
* [`src/ByteSync.ServerCommon/Interfaces/Services/IBlobStorageContainerService.cs`](diffhunk://#diff-fe61c480b6a0f99731c2c1839fb10986da84f7c0123d6d34366f5f25f47164d2R1-R11): Added a new interface defining methods and properties for managing blob storage containers.
* [`src/ByteSync.ServerCommon/Services/BlobStorageContainerService.cs`](diffhunk://#diff-8a3f2a8dbf28412be2781ca342c238a03786575329c535ef63ae25186c350c66R1-R59): Implemented the `BlobStorageContainerService` class, which provides methods to build blob container clients and manage shared key credentials.

### Refactoring:
* [`src/ByteSync.ServerCommon/Services/BlobUrlService.cs`](diffhunk://#diff-63b94d15379a04bd06733d0e5fadaf7386cd348d2338a8296e8817634ce37f36L1-R17): Refactored `BlobUrlService` to use `IBlobStorageContainerService` for blob container and credential management, removing duplicate methods such as `BuildBlobContainerClient` and `BuildStorageSharedKeyCredential`. [[1]](diffhunk://#diff-63b94d15379a04bd06733d0e5fadaf7386cd348d2338a8296e8817634ce37f36L1-R17) [[2]](diffhunk://#diff-63b94d15379a04bd06733d0e5fadaf7386cd348d2338a8296e8817634ce37f36L36-R33) [[3]](diffhunk://#diff-63b94d15379a04bd06733d0e5fadaf7386cd348d2338a8296e8817634ce37f36L69-L99) [[4]](diffhunk://#diff-63b94d15379a04bd06733d0e5fadaf7386cd348d2338a8296e8817634ce37f36L109-R79) [[5]](diffhunk://#diff-63b94d15379a04bd06733d0e5fadaf7386cd348d2338a8296e8817634ce37f36L127-R96)

### Testing:
* [`tests/ByteSync.ServerCommon.Tests/Services/BlobStorageContainerServiceTests.cs`](diffhunk://#diff-6ec8ccf5d4db3a97486d5cd0b473e7494b2fc0e2fb119541601e883bb6ff8728R1-R52): Added unit tests for `BlobStorageContainerService` to verify the validity and singleton behavior of the `StorageSharedKeyCredential`.