### PR TITLE
Data nodes and local sync - Misc improvements 07/08

### DIFF
--- a/src/ByteSync.Functions/Program.cs
+++ b/src/ByteSync.Functions/Program.cs
@@ -92,6 +92,16 @@ var host = new HostBuilder()
         services.Configure<AppSettings>(appSettingsSection);
         var appSettings = appSettingsSection.Get<AppSettings>();
         
+        var logger = serviceProvider.GetService<ILogger<Program>>();
+        if (logger != null && appSettings != null)
+        {
+            logger.LogInformation("AppSettings loaded - JwtDurationInSeconds: {JwtDuration}, " +
+                                  "SkipClientsVersionCheck: {SkipCheck}, DefaultStorageProvider: {DefaultStorageProvider}", 
+                appSettings.JwtDurationInSeconds, 
+                appSettings.SkipClientsVersionCheck, 
+                appSettings.DefaultStorageProvider);
+        }
+        
         services.AddClaimAuthorization();
         services.AddJwtAuthentication(appSettings!.Secret);
         

--- a/src/ByteSync.ServerCommon/Commands/CloudSessions/ResetSessionCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/CloudSessions/ResetSessionCommandHandler.cs
@@ -1,20 +1,54 @@
+using ByteSync.Common.Business.Sessions;
+using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
+using ByteSync.ServerCommon.Interfaces.Services.Clients;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace ByteSync.ServerCommon.Commands.CloudSessions;
 
 public class ResetSessionCommandHandler : IRequestHandler<ResetSessionRequest, Unit>
 {
-    private readonly ICloudSessionsService _cloudSessionsService;
+    private readonly ICloudSessionsRepository _cloudSessionsRepository;
+    private readonly IInventoryService _inventoryService;
+    private readonly ISynchronizationService _synchronizationService;
+    private readonly ISharedFilesService _sharedFilesService;
+    private readonly IInvokeClientsService _invokeClientsService;
+    private readonly ILogger<ResetSessionCommandHandler> _logger;
     
-    public ResetSessionCommandHandler(ICloudSessionsService cloudSessionsService)
+    public ResetSessionCommandHandler(ICloudSessionsRepository cloudSessionsRepository, 
+        IInventoryService inventoryService, ISynchronizationService synchronizationService,
+        ISharedFilesService sharedFilesService, IInvokeClientsService invokeClientsService,
+        ILogger<ResetSessionCommandHandler> logger)
     {
-        _cloudSessionsService = cloudSessionsService;
+        _cloudSessionsRepository = cloudSessionsRepository;
+        _inventoryService = inventoryService;
+        _synchronizationService = synchronizationService;
+        _sharedFilesService = sharedFilesService;
+        _invokeClientsService = invokeClientsService;
+        _logger = logger;
     }
     
     public async Task<Unit> Handle(ResetSessionRequest request, CancellationToken cancellationToken)
     {
-        await _cloudSessionsService.ResetSession(request.SessionId, request.Client);
+        await _cloudSessionsRepository.Update(request.SessionId, cloudSessionData =>
+        {
+            cloudSessionData.ResetSession();
+            
+            return true;
+        });
+        
+        await _inventoryService.ResetSession(request.SessionId);
+
+        await _synchronizationService.ResetSession(request.SessionId);
+        
+        await _sharedFilesService.ClearSession(request.SessionId);
+        
+        _logger.LogInformation("ResetSession: session {sessionId} reset by {clientInstanceId}", request.SessionId, request.Client.ClientInstanceId);
+        
+        await _invokeClientsService.SessionGroupExcept(request.SessionId, request.Client)
+            .SessionResetted(new BaseSessionDto(request.SessionId, request.Client.ClientInstanceId));
+
         return Unit.Value;
     }
 } 

--- a/src/ByteSync.ServerCommon/Interfaces/Services/ICloudSessionsService.cs
+++ b/src/ByteSync.ServerCommon/Interfaces/Services/ICloudSessionsService.cs
@@ -19,8 +19,6 @@ public interface ICloudSessionsService
 
     Task<List<SessionMemberInfoDTO>> GetSessionMembersInfosAsync(string sessionId);
     
-    Task<bool> ResetSession(string sessionId, Client client);
-    
     Task GiveCloudSessionPasswordExchangeKey(Client client, GiveCloudSessionPasswordExchangeKeyParameters parameters);
 
     Task InformPasswordIsWrong(Client client, string sessionId, string clientInstanceId);

--- a/tests/ByteSync.ServerCommon.Tests/Commands/CloudSessions/ResetSessionCommandHandlerTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Commands/CloudSessions/ResetSessionCommandHandlerTests.cs
@@ -1,8 +1,16 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using ByteSync.Common.Business.Sessions;
+using ByteSync.Common.Interfaces.Hub;
 using ByteSync.ServerCommon.Business.Auth;
+using ByteSync.ServerCommon.Business.Repositories;
+using ByteSync.ServerCommon.Business.Sessions;
 using ByteSync.ServerCommon.Commands.CloudSessions;
+using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
+using ByteSync.ServerCommon.Interfaces.Services.Clients;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 
@@ -12,20 +20,45 @@ namespace ByteSync.ServerCommon.Tests.Commands.CloudSessions;
 public class ResetSessionCommandHandlerTests
 {
     [Test]
-    public async Task Handle_CallsService()
+    public async Task Handle_CallsAllRequiredServices()
     {
         // Arrange
-        var mockService = new Mock<ICloudSessionsService>();
+        var mockCloudSessionsRepository = new Mock<ICloudSessionsRepository>();
+        var mockInventoryService = new Mock<IInventoryService>();
+        var mockSynchronizationService = new Mock<ISynchronizationService>();
+        var mockSharedFilesService = new Mock<ISharedFilesService>();
+        var mockInvokeClientsService = new Mock<IInvokeClientsService>();
+        var mockLogger = new Mock<ILogger<ResetSessionCommandHandler>>();
+        
         var client = new Client();
         var sessionId = "session1";
-        mockService.Setup(s => s.ResetSession(sessionId, client)).ReturnsAsync(true);
-        var handler = new ResetSessionCommandHandler(mockService.Object);
+        
+        mockCloudSessionsRepository.Setup(r => r.Update(sessionId, It.IsAny<Func<CloudSessionData, bool>>(), null, null))
+            .ReturnsAsync(new UpdateEntityResult<CloudSessionData>(null, UpdateEntityStatus.Saved));
+        mockInventoryService.Setup(s => s.ResetSession(sessionId)).Returns(Task.CompletedTask);
+        mockSynchronizationService.Setup(s => s.ResetSession(sessionId)).Returns(Task.CompletedTask);
+        mockSharedFilesService.Setup(s => s.ClearSession(sessionId)).Returns(Task.CompletedTask);
+        mockInvokeClientsService.Setup(s => s.SessionGroupExcept(sessionId, client))
+            .Returns(Mock.Of<IHubByteSyncPush>());
+        
+        var handler = new ResetSessionCommandHandler(
+            mockCloudSessionsRepository.Object,
+            mockInventoryService.Object,
+            mockSynchronizationService.Object,
+            mockSharedFilesService.Object,
+            mockInvokeClientsService.Object,
+            mockLogger.Object);
+        
         var request = new ResetSessionRequest(sessionId, client);
 
         // Act
         await handler.Handle(request, CancellationToken.None);
 
         // Assert
-        mockService.Verify(s => s.ResetSession(sessionId, client), Times.Once);
+        mockCloudSessionsRepository.Verify(r => r.Update(sessionId, It.IsAny<Func<CloudSessionData, bool>>(), null, null), Times.Once);
+        mockInventoryService.Verify(s => s.ResetSession(sessionId), Times.Once);
+        mockSynchronizationService.Verify(s => s.ResetSession(sessionId), Times.Once);
+        mockSharedFilesService.Verify(s => s.ClearSession(sessionId), Times.Once);
+        mockInvokeClientsService.Verify(s => s.SessionGroupExcept(sessionId, client), Times.Once);
     }
 } 


### PR DESCRIPTION
This pull request refactors the session reset logic in the ByteSync server codebase, moving the responsibility from `CloudSessionsService` to a more granular command handler and repository approach. It also updates the corresponding unit tests and improves logging for better observability.

### Refactoring session reset logic

* The session reset operation has been moved from the `CloudSessionsService` class to the `ResetSessionCommandHandler`, which now directly interacts with `ICloudSessionsRepository`, `IInventoryService`, `ISynchronizationService`, `ISharedFilesService`, and `IInvokeClientsService` for a more modular and testable design. (`src/ByteSync.ServerCommon/Commands/CloudSessions/ResetSessionCommandHandler.cs` [[1]](diffhunk://#diff-12c64613b78b52be06653a56c35f8abbb29cc30f0e3f121625eaf1987c023855R1-R51) `src/ByteSync.ServerCommon/Services/CloudSessionsService.cs` [[2]](diffhunk://#diff-6b03fc15ade48eb1a542c40945b0c4fd25170346ca5f6778008b5c2edbf2a0faL20-L35) [[3]](diffhunk://#diff-6b03fc15ade48eb1a542c40945b0c4fd25170346ca5f6778008b5c2edbf2a0faL234-L256) `src/ByteSync.ServerCommon/Interfaces/Services/ICloudSessionsService.cs` [[4]](diffhunk://#diff-ca21b47a661b2bae81b9580e111a11fa1b3e32133ec91ed11afda6d2a88688cdL22-L23)

### Logging and observability

* Added detailed logging of loaded application settings in `Program.cs` and of session resets in the command handler for improved monitoring and troubleshooting. (`src/ByteSync.Functions/Program.cs` [[1]](diffhunk://#diff-8e3b85876aae6fe4a8674c0aeb4b7b3b3d3d0f4da10d5e22f5d3d6eb58a53860R95-R104) `src/ByteSync.ServerCommon/Commands/CloudSessions/ResetSessionCommandHandler.cs` [[2]](diffhunk://#diff-12c64613b78b52be06653a56c35f8abbb29cc30f0e3f121625eaf1987c023855R1-R51)

### Unit test updates

* The unit test for session reset (`ResetSessionCommandHandlerTests`) has been updated to verify calls to all involved services and repositories, ensuring the new logic is properly exercised and validated. (`tests/ByteSync.ServerCommon.Tests/Commands/CloudSessions/ResetSessionCommandHandlerTests.cs` [[1]](diffhunk://#diff-e249bc82ad05f28c22809c5b1d57d957431d2576c399d0f3ad2dd83cdf7c0c97R1-R13) [[2]](diffhunk://#diff-e249bc82ad05f28c22809c5b1d57d957431d2576c399d0f3ad2dd83cdf7c0c97L15-R62)

### Dependency and interface cleanup

* Removed unused dependencies and the now-obsolete `ResetSession` method from `ICloudSessionsService`, reflecting the new separation of concerns. (`src/ByteSync.ServerCommon/Interfaces/Services/ICloudSessionsService.cs` [[1]](diffhunk://#diff-ca21b47a661b2bae81b9580e111a11fa1b3e32133ec91ed11afda6d2a88688cdL22-L23) `src/ByteSync.ServerCommon/Services/CloudSessionsService.cs` [[2]](diffhunk://#diff-6b03fc15ade48eb1a542c40945b0c4fd25170346ca5f6778008b5c2edbf2a0faL2) [[3]](diffhunk://#diff-6b03fc15ade48eb1a542c40945b0c4fd25170346ca5f6778008b5c2edbf2a0faL20-L35) [[4]](diffhunk://#diff-6b03fc15ade48eb1a542c40945b0c4fd25170346ca5f6778008b5c2edbf2a0faL234-L256)