### PR TITLE
[Feature] configure CI-based sonarcloud

### DIFF
--- a/.github/workflows/trigger-PR-pipeline.yml
+++ b/.github/workflows/trigger-PR-pipeline.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
 
 jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/sonarcloud-github-action@v5
+        with:
+          args: >
+            -Dsonar.organization=pow-software
+            -Dsonar.projectKey=POW-Software_ByteSync
+            -Dsonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   discover-tests:
     runs-on: ubuntu-latest
     outputs:
@@ -62,7 +74,16 @@ jobs:
           project="${{ matrix.testProject }}"
           safe_name=$(basename "$project" .csproj)
           echo "Running test project: $project"
-          dotnet test "$project" --no-restore --no-build --logger "trx;LogFileName=$safe_name.trx" --results-directory ./TestResults
+          dotnet test "$project" \
+            --no-restore \
+            --no-build \
+            --logger "trx;LogFileName=$safe_name.trx" \
+            --results-directory ./TestResults \
+              --collect:"XPlat Code Coverage" \
+              /p:CollectCoverage=true \
+              /p:CoverletOutput=./TestResults/coverage.opencover.xml \
+              /p:CoverletOutputFormat=opencover \
+              /p:Include=[*]*
         shell: bash
 
       - name: Upload Test Results

--- a/.github/workflows/trigger-PR-pipeline.yml
+++ b/.github/workflows/trigger-PR-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           dotnet restore --locked-mode
           dotnet clean --verbosity quiet
-          dotnet build --verbosity quiet /property:WarningLevel=0
+          dotnet build --verbosity quiet -clp:ErrorsOnly /property:WarningLevel=0
 
       - name: SonarCloud End (publish)
         run: >

--- a/.github/workflows/trigger-PR-pipeline.yml
+++ b/.github/workflows/trigger-PR-pipeline.yml
@@ -22,6 +22,12 @@ jobs:
           merge-multiple: true
           path: ./TestResults
 
+      - name: Create Client config for build
+        shell: bash
+        run: |
+          mkdir -p src/ByteSync.Client
+          echo '${{ secrets.CLIENT_LOCAL_SETTINGS_JSON }}' > src/ByteSync.Client/local.settings.json
+
       - name: Setup .NET 8 Environment
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/trigger-PR-pipeline.yml
+++ b/.github/workflows/trigger-PR-pipeline.yml
@@ -22,13 +22,36 @@ jobs:
           merge-multiple: true
           path: ./TestResults
 
-      - uses: SonarSource/sonarcloud-github-action@v5
+      - name: Setup .NET 8 Environment
+        uses: actions/setup-dotnet@v4
         with:
-          args: >
-            -Dsonar.organization=pow-software
-            -Dsonar.projectKey=POW-Software_ByteSync
-            -Dsonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
-            -Dsonar.cs.vstest.reportsPaths=**/*.trx
+          dotnet-version: '8.0.x'
+
+      - name: Install SonarScanner for .NET
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+
+      - name: SonarCloud Begin (prepare)
+        run: >
+          dotnet sonarscanner begin
+          /k:"POW-Software_ByteSync"
+          /o:"pow-software"
+          /d:sonar.host.url="https://sonarcloud.io"
+          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+          /d:sonar.cs.vstest.reportsPaths="**/*.trx"
+
+      - name: Build (no tests)
+        run: |
+          dotnet restore --locked-mode
+          dotnet clean --verbosity quiet
+          dotnet build --verbosity quiet /property:WarningLevel=0
+
+      - name: SonarCloud End (publish)
+        run: >
+          dotnet sonarscanner end
+          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger-PR-pipeline.yml
+++ b/.github/workflows/trigger-PR-pipeline.yml
@@ -7,14 +7,28 @@ on:
 
 jobs:
   sonarcloud:
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: PR-test-results-*
+          merge-multiple: true
+          path: ./TestResults
+
       - uses: SonarSource/sonarcloud-github-action@v5
         with:
           args: >
             -Dsonar.organization=pow-software
             -Dsonar.projectKey=POW-Software_ByteSync
             -Dsonar.cs.opencover.reportsPaths=**/coverage.opencover.xml
+            -Dsonar.cs.vstest.reportsPaths=**/*.trx
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -80,10 +94,8 @@ jobs:
             --logger "trx;LogFileName=$safe_name.trx" \
             --results-directory ./TestResults \
               --collect:"XPlat Code Coverage" \
-              /p:CollectCoverage=true \
-              /p:CoverletOutput=./TestResults/coverage.opencover.xml \
-              /p:CoverletOutputFormat=opencover \
-              /p:Include=[*]*
+              -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover \
+                 DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.OutputDirectory=./TestResults
         shell: bash
 
       - name: Upload Test Results


### PR DESCRIPTION
### Configure CI-based SonarCloud analysis and test coverage reporting

**Summary**
- Adds a dedicated CI job to run SonarCloud analysis on pull requests.
- Enables cross-platform code coverage collection in test jobs and publishes OpenCover reports for SonarCloud to consume.

### Why
- Provide automated, PR-driven code quality feedback through SonarCloud (issues, code smells, vulnerabilities).
- Surface and track code coverage as part of CI for visibility and maintainability.

### How it works
- The `sonarcloud` job runs on `ubuntu-latest` for PRs, authenticating with `SONAR_TOKEN` to publish analysis and decorate PRs (via `GITHUB_TOKEN`).
- Test jobs now emit OpenCover coverage reports to `./TestResults/coverage.opencover.xml`, which SonarCloud ingests using the `sonar.cs.opencover.reportsPaths` pattern.

### Requirements
- GitHub repository secrets:
  - `SONAR_TOKEN` with permissions to analyze `POW-Software_ByteSync` in the `pow-software` SonarCloud organization.
  - `GITHUB_TOKEN` is available by default; ensure it has standard PR write permissions for decoration.
- SonarCloud project exists and is bound to the repo with the specified `organization` and `projectKey`.

### Verification
- Open a PR and confirm:
  - The `sonarcloud` job runs and completes successfully.
  - SonarCloud comments/PR decoration appear with summary and Quality Gate status.
  - Coverage is reported in SonarCloud and aligns with generated `coverage.opencover.xml` files in `./TestResults`.
- Review the Test Results artifact for TRX logs and coverage output presence.
