### PR TITLE
[test] Add headless integration test infrastructure

### DIFF
--- a/tests/ByteSync.Client.IntegrationTests/ByteSync.Client.IntegrationTests.csproj
+++ b/tests/ByteSync.Client.IntegrationTests/ByteSync.Client.IntegrationTests.csproj
@@ -24,6 +24,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+        <PackageReference Include="Avalonia.Headless" Version="11.3.4" />
+        <PackageReference Include="Avalonia.Headless.NUnit" Version="11.3.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/ByteSync.Client.IntegrationTests/Services/Dialogs/DialogService_HeadlessTests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Dialogs/DialogService_HeadlessTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Autofac;
+using ByteSync.Business;
+using ByteSync.Client.IntegrationTests.TestHelpers;
+using ByteSync.Interfaces.Dialogs;
+using ByteSync.Interfaces.Services.Localizations;
+using ByteSync.Services.Dialogs;
+using ByteSync.ViewModels.Misc;
+using Moq;
+using NUnit.Framework;
+
+namespace ByteSync.Client.IntegrationTests.Services.Dialogs;
+
+public class DialogService_HeadlessTests : HeadlessIntegrationTest
+{
+    [SetUp]
+    public void Setup()
+    {
+        var dialogView = new Mock<IDialogView>();
+        dialogView
+            .Setup(d => d.ShowMessageBoxAsync(It.IsAny<MessageBoxViewModel>()))
+            .ReturnsAsync(MessageBoxResult.OK);
+
+        var localizationService = new Mock<ILocalizationService>();
+        var factory = new Mock<IMessageBoxViewModelFactory>();
+        factory.Setup(f => f.CreateMessageBoxViewModel(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string[]?>()))
+            .Returns((string titleKey, string? messageKey, string[]? args) =>
+                new MessageBoxViewModel(titleKey, messageKey, args == null ? null : new List<string>(args), localizationService.Object));
+
+        _builder.RegisterInstance(dialogView.Object).As<IDialogView>();
+        _builder.RegisterInstance(factory.Object).As<IMessageBoxViewModelFactory>();
+        RegisterType<DialogService, IDialogService>();
+        BuildMoqContainer();
+    }
+
+    [Test]
+    public async Task ShowMessageBoxAsync_ReturnsExpectedResult()
+    {
+        var service = Container.Resolve<IDialogService>();
+        var vm = service.CreateMessageBoxViewModel("title");
+        var result = await service.ShowMessageBoxAsync(vm);
+        Assert.That(result, Is.EqualTo(MessageBoxResult.OK));
+    }
+}

--- a/tests/ByteSync.Client.IntegrationTests/Services/Navigations/NavigationService_HeadlessTests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Navigations/NavigationService_HeadlessTests.cs
@@ -1,0 +1,32 @@
+using Autofac;
+using ByteSync.Business.Navigations;
+using ByteSync.Client.IntegrationTests.TestHelpers;
+using ByteSync.Interfaces.Controls.Navigations;
+using ByteSync.Services.Navigations;
+using NUnit.Framework;
+
+namespace ByteSync.Client.IntegrationTests.Services.Navigations;
+
+public class NavigationService_HeadlessTests : HeadlessIntegrationTest
+{
+    [SetUp]
+    public void Setup()
+    {
+        RegisterType<NavigationService, INavigationService>();
+        BuildMoqContainer();
+    }
+
+    [Test]
+    public void NavigateToHomePublishesDetails()
+    {
+        var service = Container.Resolve<INavigationService>();
+        NavigationDetails? details = null;
+        service.CurrentPanel.Subscribe(d => details = d);
+
+        service.NavigateTo(NavigationPanel.Home);
+
+        Assert.That(details?.NavigationPanel, Is.EqualTo(NavigationPanel.Home));
+        Assert.That(details?.IconName, Is.EqualTo("RegularHomeAlt"));
+        Assert.That(details?.TitleLocalizationName, Is.EqualTo("Shell_Home"));
+    }
+}

--- a/tests/ByteSync.Client.IntegrationTests/TestHelpers/HeadlessIntegrationTest.cs
+++ b/tests/ByteSync.Client.IntegrationTests/TestHelpers/HeadlessIntegrationTest.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using ByteSync;
+using ByteSync.TestsCommon;
+using NUnit.Framework;
+
+namespace ByteSync.Client.IntegrationTests.TestHelpers;
+
+public abstract class HeadlessIntegrationTest : IntegrationTest
+{
+    private static bool _initialized;
+
+    [OneTimeSetUp]
+    public static void GlobalSetup()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        AppBuilder.Configure<TestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions())
+            .SetupWithoutStarting();
+
+        _initialized = true;
+    }
+
+    protected Task ExecuteOnUiThread(Func<Task> action)
+    {
+        var tcs = new TaskCompletionSource();
+        Dispatcher.UIThread.InvokeAsync(async () =>
+        {
+            await action();
+            tcs.SetResult();
+        });
+        return tcs.Task;
+    }
+
+    protected Task<T> ExecuteOnUiThread<T>(Func<Task<T>> action)
+    {
+        var tcs = new TaskCompletionSource<T>();
+        Dispatcher.UIThread.InvokeAsync(async () =>
+        {
+            var result = await action();
+            tcs.SetResult(result);
+        });
+        return tcs.Task;
+    }
+
+    private class TestApp : Application
+    {
+    }
+}

--- a/tests/ByteSync.Client.IntegrationTests/ViewModels/MainWindow/MainWindowViewModel_HeadlessTests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/ViewModels/MainWindow/MainWindowViewModel_HeadlessTests.cs
@@ -1,0 +1,78 @@
+using System.Reactive.Linq;
+using Autofac;
+using Autofac.Features.Indexed;
+using ByteSync.Business.Navigations;
+using ByteSync.Business.Sessions;
+using ByteSync.Client.IntegrationTests.TestHelpers;
+using ByteSync.Interfaces.Controls.Applications;
+using ByteSync.Interfaces.Controls.Navigations;
+using ByteSync.Interfaces.Repositories;
+using ByteSync.Interfaces.Services.Sessions;
+using ByteSync.Interfaces.Services.Sessions.Connecting;
+using ByteSync.Services.Navigations;
+using ByteSync.ViewModels;
+using ByteSync.ViewModels.Announcements;
+using ByteSync.ViewModels.Headers;
+using ByteSync.ViewModels.Misc;
+using Moq;
+using NUnit.Framework;
+using ReactiveUI;
+
+namespace ByteSync.Client.IntegrationTests.ViewModels.MainWindow;
+
+public class MainWindowViewModel_HeadlessTests : HeadlessIntegrationTest
+{
+    [SetUp]
+    public void Setup()
+    {
+        var flyout = new FlyoutContainerViewModel { CanCloseCurrentFlyout = true };
+        var header = new HeaderViewModel();
+        var announcement = new AnnouncementViewModel();
+
+        var panelViewModels = new Mock<IIndex<NavigationPanel, IRoutableViewModel>>();
+        var dummy = new Mock<IRoutableViewModel>().Object;
+        panelViewModels.Setup(p => p[It.IsAny<NavigationPanel>()]).Returns(dummy);
+        _builder.RegisterInstance(panelViewModels.Object);
+
+        var zoomService = new Mock<IZoomService>();
+        zoomService.SetupGet(z => z.ZoomLevel).Returns(Observable.Return(100));
+        _builder.RegisterInstance(zoomService.Object).As<IZoomService>();
+
+        var cloudService = new Mock<ICloudSessionConnectionService>();
+        cloudService.Setup(s => s.CanLogOutOrShutdown).Returns(Observable.Return(true));
+        _builder.RegisterInstance(cloudService.Object).As<ICloudSessionConnectionService>();
+
+        var repository = new Mock<ICloudSessionConnectionRepository>();
+        repository.Setup(r => r.ConnectionStatusObservable).Returns(Observable.Never<SessionConnectionStatus>());
+        _builder.RegisterInstance(repository.Object).As<ICloudSessionConnectionRepository>();
+
+        _builder.RegisterInstance(flyout);
+        _builder.RegisterInstance(header);
+        _builder.RegisterInstance(announcement);
+        RegisterType<NavigationService, INavigationService>();
+        RegisterType<MainWindowViewModel>();
+        BuildMoqContainer();
+    }
+
+    [Test]
+    public async Task NavigateToHomeUpdatesRouter()
+    {
+        var navigationService = Container.Resolve<INavigationService>();
+        var viewModel = Container.Resolve<MainWindowViewModel>();
+
+        await ExecuteOnUiThread(() =>
+        {
+            navigationService.NavigateTo(NavigationPanel.Home);
+            Assert.That(viewModel.Router.NavigationStack.Count, Is.EqualTo(1));
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    public async Task OnCloseWindowRequested_WithCtrlDown_ReturnsTrue()
+    {
+        var viewModel = Container.Resolve<MainWindowViewModel>();
+        var result = await ExecuteOnUiThread(() => viewModel.OnCloseWindowRequested(true));
+        Assert.That(result, Is.True);
+    }
+}


### PR DESCRIPTION
## Summary
- add Avalonia headless dependencies for integration tests
- introduce headless test base class and sample tests

## Testing
- `dotnet build ByteSync.sln --verbosity quiet /property:WarningLevel=0`
- `dotnet test tests/ByteSync.Client.IntegrationTests/ByteSync.Client.IntegrationTests.csproj` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68a407b205e08333996384e8607748fa