### PR TITLE
[feature] Adjust temporary upload settings

### DIFF
--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
@@ -45,7 +45,7 @@ public class FileUploadProcessor : IFileUploadProcessor
         _progressState = new UploadProgressState();
         
         // Start upload workers
-        for (var i = 0; i < 6; i++)
+        for (var i = 0; i < 2; i++)
         {
             _ = Task.Run(() => _fileUploadWorker.UploadAvailableSlicesAsync(_fileUploadCoordinator.AvailableSlices, _progressState));
         }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
@@ -62,7 +62,7 @@ public class FileUploadProcessor : IFileUploadProcessor
         if (_progressState.LastException != null)
         {
             var source = _localFileToUpload ?? "a stream";
-            throw new Exception($"An error occured while uploading '{source}' / sharedFileDefinition.Id:{sharedFileDefinition.Id}",
+            throw new InvalidOperationException($"An error occured while uploading '{source}' / sharedFileDefinition.Id:{sharedFileDefinition.Id}",
                 _progressState.LastException);
         }
 

--- a/src/ByteSync.Client/Services/Encryptions/SlicerEncrypter.cs
+++ b/src/ByteSync.Client/Services/Encryptions/SlicerEncrypter.cs
@@ -103,11 +103,8 @@ public class SlicerEncrypter : ISlicerEncrypter
                 fileUploaderSlice = new FileUploaderSlice(TotalGeneratedFiles, memoryStream);
             }
             
-            using (var cts = new CancellationTokenSource())
-            {
-                await cryptoStream.WriteAsync(bytes.AsMemory(0, readBytes), cts.Token);;
-            }
-            
+            await cryptoStream.WriteAsync(bytes.AsMemory(0, readBytes), CancellationToken.None);
+           
             var sizeToRead = BufferSize;
             if (thisSessionReadBytes + sizeToRead > MaxSliceLength)
             {

--- a/src/ByteSync.Client/Services/Encryptions/SlicerEncrypter.cs
+++ b/src/ByteSync.Client/Services/Encryptions/SlicerEncrypter.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Security.Cryptography;
-using System.Threading.Tasks;
 using ByteSync.Business.Communications.Transfers;
 using ByteSync.Common.Business.SharedFiles;
 using ByteSync.Interfaces.Controls.Encryptions;
@@ -22,8 +21,7 @@ public class SlicerEncrypter : ISlicerEncrypter
         _logger = logger;
             
         BufferSize = 4096;
-        MaxSliceLength = 64 * 1024 * 1024; // 64 Mo
-        MaxSliceLength = 4 * 1024 * 1024; // 4 Mo
+        MaxSliceLength = 1024 * 1024; // 1 Mb
     }
         
     public void Initialize(FileInfo fileToEncrypt, SharedFileDefinition sharedFileDefinition)

--- a/src/ByteSync.Client/Services/Encryptions/SlicerEncrypter.cs
+++ b/src/ByteSync.Client/Services/Encryptions/SlicerEncrypter.cs
@@ -103,9 +103,10 @@ public class SlicerEncrypter : ISlicerEncrypter
                 fileUploaderSlice = new FileUploaderSlice(TotalGeneratedFiles, memoryStream);
             }
             
-            var cts = new CancellationTokenSource();
-            CancellationToken token = cts.Token;
-            await cryptoStream.WriteAsync(bytes.AsMemory(0, readBytes), token);
+            using (var cts = new CancellationTokenSource())
+            {
+                await cryptoStream.WriteAsync(bytes.AsMemory(0, readBytes), cts.Token);;
+            }
             
             var sizeToRead = BufferSize;
             if (thisSessionReadBytes + sizeToRead > MaxSliceLength)

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
@@ -14,17 +14,17 @@ namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
 [TestFixture]
 public class FileUploadProcessorTests
 {
-    private Mock<ISlicerEncrypter> _mockSlicerEncrypter;
-    private Mock<ILogger> _mockLogger;
-    private Mock<IFileUploadCoordinator> _mockFileUploadCoordinator;
-    private Mock<IFileSlicer> _mockFileSlicer;
-    private Mock<IFileUploadWorker> _mockFileUploadWorker;
-    private Mock<IFilePartUploadAsserter> _mockFilePartUploadAsserter;
-    private SharedFileDefinition _sharedFileDefinition;
-    private string _testFilePath;
-    private MemoryStream _testMemoryStream;
-    private FileUploadProcessor _fileUploadProcessor;
-    private SemaphoreSlim _semaphoreSlim;
+    private Mock<ISlicerEncrypter> _mockSlicerEncrypter = null!;
+    private Mock<ILogger> _mockLogger = null!;
+    private Mock<IFileUploadCoordinator> _mockFileUploadCoordinator = null!;
+    private Mock<IFileSlicer> _mockFileSlicer = null!;
+    private Mock<IFileUploadWorker> _mockFileUploadWorker = null!;
+    private Mock<IFilePartUploadAsserter> _mockFilePartUploadAsserter = null!;
+    private SharedFileDefinition _sharedFileDefinition = null!;
+    private string _testFilePath = null!;
+    private MemoryStream _testMemoryStream = null!;
+    private FileUploadProcessor _fileUploadProcessor = null!;
+    private SemaphoreSlim _semaphoreSlim = null!;
 
     [SetUp]
     public void SetUp()

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
@@ -116,7 +116,7 @@ public class FileUploadProcessorTests
         await _fileUploadProcessor.ProcessUpload(_sharedFileDefinition);
 
         // Assert
-        _mockFileUploadWorker.Verify(x => x.UploadAvailableSlicesAsync(It.IsAny<Channel<FileUploaderSlice>>(), It.IsAny<UploadProgressState>()), Times.Exactly(6));
+        _mockFileUploadWorker.Verify(x => x.UploadAvailableSlicesAsync(It.IsAny<Channel<FileUploaderSlice>>(), It.IsAny<UploadProgressState>()), Times.Exactly(2));
     }
 
     [Test]


### PR DESCRIPTION
### Summary
Reduce initial upload parallelism and slice size to improve stability on first-run uploads and lower resource usage on constrained networks/devices.

### Changes
- File: `src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs`
  - Decrease upload workers from 6 to 2.
- File: `src/ByteSync.Client/Services/Encryptions/SlicerEncrypter.cs`
  - Set `MaxSliceLength` to 1 MB (was effectively 4 MB).
  - Remove unused `System.Threading.Tasks` using.
  - Clean up duplicate/overwritten `MaxSliceLength` assignment.

### Rationale
- Reduce simultaneous slice uploads to avoid saturating bandwidth and hitting server throttles during initial sessions.
- Smaller slice size:
  - Lowers peak memory usage and retry costs.
  - Improves resume granularity and fairness across members.
  - Better behavior on variable/slow connections.

### Impact
- Expected: smoother first-time upload experience with lower CPU/memory/network spikes.
- Trade-off: potential reduction in peak throughput; increased number of requests for large files.
- No breaking API changes.