### PR TITLE
[Refactor] Restructure code and add necessary tests

### DIFF
--- a/src/ByteSync.Client/Business/Communications/Transfers/SliceUploadMetric.cs
+++ b/src/ByteSync.Client/Business/Communications/Transfers/SliceUploadMetric.cs
@@ -1,0 +1,11 @@
+namespace ByteSync.Business.Communications.Transfers;
+
+public class SliceUploadMetric
+{
+    public int PartNumber { get; set; }
+    public long Bytes { get; set; }
+    public long DurationMs { get; set; }
+    public double BandwidthKbps { get; set; }
+}
+
+

--- a/src/ByteSync.Client/Business/Communications/Transfers/SliceUploadMetric.cs
+++ b/src/ByteSync.Client/Business/Communications/Transfers/SliceUploadMetric.cs
@@ -2,10 +2,14 @@ namespace ByteSync.Business.Communications.Transfers;
 
 public class SliceUploadMetric
 {
+    public int TaskId { get; set; }
+
     public int PartNumber { get; set; }
+    
     public long Bytes { get; set; }
-    public long DurationMs { get; set; }
-    public double BandwidthKbps { get; set; }
+    
+    public long ElapsedtimeMs { get; set; }
+
 }
 
 

--- a/src/ByteSync.Client/Business/Communications/Transfers/UploadProgressState.cs
+++ b/src/ByteSync.Client/Business/Communications/Transfers/UploadProgressState.cs
@@ -6,7 +6,6 @@ public class UploadProgressState
     public int TotalUploadedSlices { get; set; }
     public int ConcurrentUploads { get; set; }
     public int MaxConcurrentUploads { get; set; }
-    public Exception? LastException { get; set; }
     public DateTimeOffset? StartTimeUtc { get; set; }
     public DateTimeOffset? EndTimeUtc { get; set; }
     public long TotalCreatedBytes { get; set; }

--- a/src/ByteSync.Client/Business/Communications/Transfers/UploadProgressState.cs
+++ b/src/ByteSync.Client/Business/Communications/Transfers/UploadProgressState.cs
@@ -7,4 +7,12 @@ public class UploadProgressState
     public int ConcurrentUploads { get; set; }
     public int MaxConcurrentUploads { get; set; }
     public Exception? LastException { get; set; }
+    public DateTimeOffset? StartTimeUtc { get; set; }
+    public DateTimeOffset? EndTimeUtc { get; set; }
+    public long TotalCreatedBytes { get; set; }
+    public long TotalUploadedBytes { get; set; }
+    public long? LastSliceUploadedBytes { get; set; }
+    public long? LastSliceUploadDurationMs { get; set; }
+    public List<Exception> Exceptions { get; } = new System.Collections.Generic.List<Exception>();
+    public List<SliceUploadMetric> SliceMetrics { get; } = new System.Collections.Generic.List<SliceUploadMetric>();
 } 

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
@@ -54,6 +54,7 @@ public class FileSlicer : IFileSlicer
                     try
                     {
                         progressState.TotalCreatedSlices += 1;
+                        progressState.TotalCreatedBytes += fileUploaderSlice.MemoryStream.Length;
                     }
                     finally
                     {
@@ -77,6 +78,7 @@ public class FileSlicer : IFileSlicer
             try
             {
                 progressState.LastException = ex;
+                progressState.Exceptions.Add(ex);
             }
             finally
             {

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
@@ -77,7 +77,6 @@ public class FileSlicer : IFileSlicer
             await _semaphoreSlim.WaitAsync();
             try
             {
-                progressState.LastException = ex;
                 progressState.Exceptions.Add(ex);
             }
             finally

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
@@ -43,6 +43,7 @@ public class FileUploadProcessor : IFileUploadProcessor
     public async Task ProcessUpload(SharedFileDefinition sharedFileDefinition, int? maxSliceLength = null)
     {
         _progressState = new UploadProgressState();
+        _progressState.StartTimeUtc = DateTimeOffset.UtcNow;
         
         // Start upload workers
         for (var i = 0; i < 2; i++)
@@ -69,7 +70,20 @@ public class FileUploadProcessor : IFileUploadProcessor
         var totalCreatedSlices = GetTotalCreatedSlices();
         await _filePartUploadAsserter.AssertUploadIsFinished(sharedFileDefinition, totalCreatedSlices);
         
-        _logger.LogInformation("FileUploadProcessor: E2EE upload of {SharedFileDefinitionId} is finished", sharedFileDefinition.Id);
+        _progressState.EndTimeUtc = DateTimeOffset.UtcNow;
+        var durationMs = (_progressState.EndTimeUtc - _progressState.StartTimeUtc)?.TotalMilliseconds;
+        var totalBytes = _progressState.TotalUploadedBytes;
+        var bandwidthKbps = durationMs.HasValue && durationMs.Value > 0
+            ? (totalBytes * 8.0) / durationMs.Value
+            : 0.0;
+        _logger.LogInformation(
+            "FileUploadProcessor: E2EE upload of {SharedFileDefinitionId} is finished in {DurationMs} ms, uploaded {UploadedKB} KB, max concurrency {MaxConc}, approx bandwidth {Kbps:F2} kbps, {Errors} error(s)",
+            sharedFileDefinition.Id,
+            durationMs,
+            totalBytes / 1024d,
+            _progressState.MaxConcurrentUploads,
+            bandwidthKbps,
+            _progressState.Exceptions.Count);
     }
 
     public int GetTotalCreatedSlices()

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
@@ -60,11 +60,12 @@ public class FileUploadProcessor : IFileUploadProcessor
 
         _slicerEncrypter.Dispose();
 
-        if (_progressState.LastException != null)
+        if (_progressState.Exceptions != null && _progressState.Exceptions.Count > 0)
         {
             var source = _localFileToUpload ?? "a stream";
+            var lastException = _progressState.Exceptions[_progressState.Exceptions.Count - 1];
             throw new InvalidOperationException($"An error occured while uploading '{source}' / sharedFileDefinition.Id:{sharedFileDefinition.Id}",
-                _progressState.LastException);
+                lastException);
         }
 
         var totalCreatedSlices = GetTotalCreatedSlices();
@@ -83,7 +84,7 @@ public class FileUploadProcessor : IFileUploadProcessor
             totalBytes / 1024d,
             _progressState.MaxConcurrentUploads,
             bandwidthKbps,
-            _progressState.Exceptions.Count);
+            _progressState.Exceptions!.Count);
     }
 
     public int GetTotalCreatedSlices()

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadProcessor.cs
@@ -45,7 +45,7 @@ public class FileUploadProcessor : IFileUploadProcessor
         _progressState = new UploadProgressState();
         
         // Start upload workers
-        for (var i = 0; i < 6; i++)
+        for (var i = 0; i < 2; i++)
         {
             _ = Task.Run(() => _fileUploadWorker.UploadAvailableSlicesAsync(_fileUploadCoordinator.AvailableSlices, _progressState));
         }
@@ -62,7 +62,7 @@ public class FileUploadProcessor : IFileUploadProcessor
         if (_progressState.LastException != null)
         {
             var source = _localFileToUpload ?? "a stream";
-            throw new Exception($"An error occured while uploading '{source}' / sharedFileDefinition.Id:{sharedFileDefinition.Id}",
+            throw new InvalidOperationException($"An error occured while uploading '{source}' / sharedFileDefinition.Id:{sharedFileDefinition.Id}",
                 _progressState.LastException);
         }
 

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
@@ -91,15 +91,14 @@ public class FileUploadWorker : IFileUploadWorker
                             var sliceBytes = slice.MemoryStream?.Length ?? 0L;
                             progressState.TotalUploadedBytes += sliceBytes;
                             var elapsedMs = sliceStart.ElapsedMilliseconds;
-                            var kbps = elapsedMs > 0 ? (sliceBytes * 8.0) / elapsedMs : 0.0;
                             progressState.LastSliceUploadDurationMs = elapsedMs;
                             progressState.LastSliceUploadedBytes = sliceBytes;
                             progressState.SliceMetrics.Add(new SliceUploadMetric
                             {
+                                TaskId = Environment.CurrentManagedThreadId,
                                 PartNumber = slice.PartNumber,
                                 Bytes = sliceBytes,
-                                DurationMs = elapsedMs,
-                                BandwidthKbps = kbps
+                                ElapsedtimeMs = elapsedMs,
                             });
                         }
                         finally
@@ -127,7 +126,6 @@ public class FileUploadWorker : IFileUploadWorker
                     await _semaphoreSlim.WaitAsync();
                     try
                     {
-                        progressState.LastException = ex;
                         progressState.Exceptions.Add(ex);
                     }
                     finally

--- a/src/ByteSync.Client/Services/Themes/ThemeFactory.cs
+++ b/src/ByteSync.Client/Services/Themes/ThemeFactory.cs
@@ -131,7 +131,7 @@ public class ThemeFactory : IThemeFactory
             colorScheme.MainWindowTopColor = colorScheme.VeryLightGray;
             colorScheme.MainWindowBottomColor = Color.FromArgb(0xFF, 0x04, 0x04, 0x04);
             
-            ComputeSecondaryColors(colorScheme, secondaryColorHue);
+            ComputeSecondaryColors(colorScheme, secondaryColorHue, themeMode);
             
             colorScheme.StatusMainBackGroundBrush = new SolidColorBrush(colorScheme.StatusMainBackGround.AvaloniaColor);
             colorScheme.StatusSecondaryBackGroundBrush = new SolidColorBrush(colorScheme.StatusSecondaryBackGround.AvaloniaColor);
@@ -213,7 +213,7 @@ public class ThemeFactory : IThemeFactory
             colorScheme.MainWindowTopColor = Color.FromArgb(0xFF, 0xFA, 0xFA, 0xFA);
             colorScheme.MainWindowBottomColor = Color.FromArgb(0xFF, 0xEF, 0xEF, 0xEF);
             
-            ComputeSecondaryColors(colorScheme, secondaryColorHue);
+            ComputeSecondaryColors(colorScheme, secondaryColorHue, themeMode);
             
             colorScheme.StatusMainBackGroundBrush = new SolidColorBrush(colorScheme.StatusMainBackGround.AvaloniaColor);
             colorScheme.StatusSecondaryBackGroundBrush = new SolidColorBrush(colorScheme.StatusSecondaryBackGround.AvaloniaColor);
@@ -227,7 +227,7 @@ public class ThemeFactory : IThemeFactory
         return colorScheme;
     }
     
-    private void ComputeSecondaryColors(ColorScheme colorScheme, double secondaryColorHue)
+    private void ComputeSecondaryColors(ColorScheme colorScheme, double secondaryColorHue, ThemeModes themeMode)
     {
         for (int i = 1; i <= 3; i++)
         {
@@ -241,9 +241,18 @@ public class ThemeFactory : IThemeFactory
         
         colorScheme.OtherMemberSecondaryBackGround = colorScheme.OtherMemberBackGround
             .WithHue(secondaryColorHue);
-        
-        colorScheme.StatusSecondaryBackGround = colorScheme.StatusMainBackGround
-            .WithHue(secondaryColorHue);
+
+        if (themeMode == ThemeModes.Dark)
+        {
+            colorScheme.StatusSecondaryBackGround = colorScheme.StatusMainBackGround
+                .WithHue(secondaryColorHue)
+                .AdjustSaturationValue(0, +0.20);
+        }
+        else
+        {
+            colorScheme.StatusSecondaryBackGround = colorScheme.StatusMainBackGround
+                .WithHue(secondaryColorHue);
+        }
     }
 
     private static void ComputeAttenuations(ColorScheme colorScheme)

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/DateIsCopiedCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/DateIsCopiedCommandHandler.cs
@@ -1,17 +1,13 @@
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
-using MediatR;
 using Microsoft.Extensions.Logging;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class DateIsCopiedCommandHandler : IRequestHandler<DateIsCopiedRequest>
+public class DateIsCopiedCommandHandler : ActionCompletedHandlerBase<DateIsCopiedRequest>
 {
-    private readonly ITrackingActionRepository _trackingActionRepository;
-    private readonly ISynchronizationStatusCheckerService _synchronizationStatusCheckerService;
-    private readonly ISynchronizationProgressService _synchronizationProgressService;
-    private readonly ISynchronizationService _synchronizationService;
-    private readonly ILogger<DateIsCopiedCommandHandler> _logger;
+    protected override string EmptyIdsLog => "DateIsCopied: no action group IDs were provided for the operation";
+    protected override string DoneLogTemplate => "Date is copied for session {SessionId} with {ActionCount} actions";
 
     public DateIsCopiedCommandHandler(
         ITrackingActionRepository trackingActionRepository,
@@ -19,51 +15,7 @@ public class DateIsCopiedCommandHandler : IRequestHandler<DateIsCopiedRequest>
         ISynchronizationProgressService synchronizationProgressService,
         ISynchronizationService synchronizationService,
         ILogger<DateIsCopiedCommandHandler> logger)
+        : base(trackingActionRepository, synchronizationStatusCheckerService, synchronizationProgressService, synchronizationService, logger)
     {
-        _trackingActionRepository = trackingActionRepository;
-        _synchronizationStatusCheckerService = synchronizationStatusCheckerService;
-        _synchronizationProgressService = synchronizationProgressService;
-        _synchronizationService = synchronizationService;
-        _logger = logger;
-    }
-    
-    public async Task Handle(DateIsCopiedRequest request, CancellationToken cancellationToken)
-    {
-        if (request.ActionsGroupIds.Count == 0)
-        {
-            _logger.LogInformation("DateIsCopied: no action group IDs were provided for the operation");
-            return;
-        }
-        
-        bool needSendSynchronizationUpdated = false;
-        
-        var result = await _trackingActionRepository.AddOrUpdate(request.SessionId, request.ActionsGroupIds, (trackingAction, synchronization) =>
-        {
-            if (!_synchronizationStatusCheckerService.CheckSynchronizationCanBeUpdated(synchronization))
-            {
-                return false;
-            }
-            
-            bool wasTrackingActionFinished = trackingAction.IsFinished;
-            
-            trackingAction.AddSuccessOnTarget(request.Client.ClientInstanceId);
-            
-            if (!wasTrackingActionFinished && trackingAction.IsFinished)
-            {
-                synchronization.Progress.FinishedActionsCount += 1;
-            }
-            
-            needSendSynchronizationUpdated = _synchronizationService.CheckSynchronizationIsFinished(synchronization);
-
-            return true;
-        });
-
-        if (result.IsSuccess)
-        {
-            await _synchronizationProgressService.UpdateSynchronizationProgress(result, needSendSynchronizationUpdated);
-        }
-        
-        _logger.LogInformation("Date is copied for session {SessionId} with {ActionCount} actions", 
-            request.SessionId, request.ActionsGroupIds.Count);
     }
 }

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/DateIsCopiedRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/DateIsCopiedRequest.cs
@@ -1,9 +1,8 @@
 using ByteSync.ServerCommon.Business.Auth;
-using MediatR;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class DateIsCopiedRequest : IRequest
+public class DateIsCopiedRequest : IActionCompletedRequest
 {
     public DateIsCopiedRequest(string sessionId, Client client, List<string> actionsGroupIds)
     {

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/DirectoryIsCreatedCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/DirectoryIsCreatedCommandHandler.cs
@@ -1,17 +1,13 @@
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
-using MediatR;
 using Microsoft.Extensions.Logging;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class DirectoryIsCreatedCommandHandler : IRequestHandler<DirectoryIsCreatedRequest>
+public class DirectoryIsCreatedCommandHandler : ActionCompletedHandlerBase<DirectoryIsCreatedRequest>
 {
-    private readonly ITrackingActionRepository _trackingActionRepository;
-    private readonly ISynchronizationStatusCheckerService _synchronizationStatusCheckerService;
-    private readonly ISynchronizationProgressService _synchronizationProgressService;
-    private readonly ISynchronizationService _synchronizationService;
-    private readonly ILogger<DirectoryIsCreatedCommandHandler> _logger;
+    protected override string EmptyIdsLog => "DirectoryIsCreated: no action group IDs provided";
+    protected override string DoneLogTemplate => "Directory is created for session {SessionId} with {ActionCount} actions";
 
     public DirectoryIsCreatedCommandHandler(
         ITrackingActionRepository trackingActionRepository,
@@ -19,51 +15,7 @@ public class DirectoryIsCreatedCommandHandler : IRequestHandler<DirectoryIsCreat
         ISynchronizationProgressService synchronizationProgressService,
         ISynchronizationService synchronizationService,
         ILogger<DirectoryIsCreatedCommandHandler> logger)
+        : base(trackingActionRepository, synchronizationStatusCheckerService, synchronizationProgressService, synchronizationService, logger)
     {
-        _trackingActionRepository = trackingActionRepository;
-        _synchronizationStatusCheckerService = synchronizationStatusCheckerService;
-        _synchronizationProgressService = synchronizationProgressService;
-        _synchronizationService = synchronizationService;
-        _logger = logger;
-    }
-    
-    public async Task Handle(DirectoryIsCreatedRequest request, CancellationToken cancellationToken)
-    {
-        if (request.ActionsGroupIds.Count == 0)
-        {
-            _logger.LogInformation("Directory creation failed: no action group IDs provided");
-            return;
-        }
-        
-        bool needSendSynchronizationUpdated = false;
-        
-        var result = await _trackingActionRepository.AddOrUpdate(request.SessionId, request.ActionsGroupIds, (trackingAction, synchronization) =>
-        {
-            if (!_synchronizationStatusCheckerService.CheckSynchronizationCanBeUpdated(synchronization))
-            {
-                return false;
-            }
-            
-            bool wasTrackingActionFinished = trackingAction.IsFinished;
-            
-            trackingAction.AddSuccessOnTarget(request.Client.ClientInstanceId);
-            
-            if (!wasTrackingActionFinished && trackingAction.IsFinished)
-            {
-                synchronization.Progress.FinishedActionsCount += 1;
-            }
-            
-            needSendSynchronizationUpdated = _synchronizationService.CheckSynchronizationIsFinished(synchronization);
-
-            return true;
-        });
-
-        if (result.IsSuccess)
-        {
-            await _synchronizationProgressService.UpdateSynchronizationProgress(result, needSendSynchronizationUpdated);
-        }
-        
-        _logger.LogInformation("Directory is created for session {SessionId} with {ActionCount} actions", 
-            request.SessionId, request.ActionsGroupIds.Count);
     }
 }

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/DirectoryIsCreatedRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/DirectoryIsCreatedRequest.cs
@@ -1,9 +1,8 @@
 using ByteSync.ServerCommon.Business.Auth;
-using MediatR;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class DirectoryIsCreatedRequest : IRequest
+public class DirectoryIsCreatedRequest : IActionCompletedRequest
 {
     public DirectoryIsCreatedRequest(string sessionId, Client client, List<string> actionsGroupIds)
     {

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/ErrorOccurredHandlerBase.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/ErrorOccurredHandlerBase.cs
@@ -1,0 +1,96 @@
+using ByteSync.ServerCommon.Interfaces.Repositories;
+using ByteSync.ServerCommon.Interfaces.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace ByteSync.ServerCommon.Commands.Synchronizations;
+
+public abstract class ErrorOccurredHandlerBase<TRequest> : IRequestHandler<TRequest>
+    where TRequest : IActionErrorRequest
+{
+    protected readonly ITrackingActionRepository _trackingActionRepository;
+    protected readonly ISynchronizationStatusCheckerService _synchronizationStatusCheckerService;
+    protected readonly ISynchronizationProgressService _synchronizationProgressService;
+    protected readonly ISynchronizationService _synchronizationService;
+    protected readonly ILogger _logger;
+
+    protected ErrorOccurredHandlerBase(
+        ITrackingActionRepository trackingActionRepository,
+        ISynchronizationStatusCheckerService synchronizationStatusCheckerService,
+        ISynchronizationProgressService synchronizationProgressService,
+        ISynchronizationService synchronizationService,
+        ILogger logger)
+    {
+        _trackingActionRepository = trackingActionRepository;
+        _synchronizationStatusCheckerService = synchronizationStatusCheckerService;
+        _synchronizationProgressService = synchronizationProgressService;
+        _synchronizationService = synchronizationService;
+        _logger = logger;
+    }
+
+    protected abstract string EmptyIdsLog { get; }
+    protected abstract string DoneLogTemplate { get; }
+
+    protected abstract List<string>? GetActionsGroupIds(TRequest request);
+
+    public async Task Handle(TRequest request, CancellationToken cancellationToken)
+    {
+        var actionGroupIds = GetActionsGroupIds(request);
+        if (actionGroupIds == null || actionGroupIds.Count == 0)
+        {
+            _logger.LogInformation(EmptyIdsLog);
+            return;
+        }
+
+        var needSendSynchronizationUpdated = false;
+
+        var result = await _trackingActionRepository.AddOrUpdate(request.SessionId, actionGroupIds, (trackingAction, synchronization) =>
+        {
+            if (!_synchronizationStatusCheckerService.CheckSynchronizationCanBeUpdated(synchronization))
+            {
+                return false;
+            }
+
+            var wasTrackingActionFinished = trackingAction.IsFinished;
+            var isNewError = !trackingAction.IsError;
+
+            if (trackingAction.SourceClientInstanceId == request.Client.ClientInstanceId)
+            {
+                trackingAction.IsSourceSuccess = false;
+            }
+            else
+            {
+                if (trackingAction.TargetClientInstanceIds.Contains(request.Client.ClientInstanceId))
+                {
+                    trackingAction.AddErrorOnTarget(request.Client.ClientInstanceId);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Client is not a target of the action");
+                }
+            }
+
+            if (isNewError)
+            {
+                synchronization.Progress.ErrorsCount += 1;
+            }
+            if (!wasTrackingActionFinished && trackingAction.IsFinished)
+            {
+                synchronization.Progress.FinishedActionsCount += 1;
+            }
+
+            needSendSynchronizationUpdated = _synchronizationService.CheckSynchronizationIsFinished(synchronization);
+
+            return true;
+        });
+
+        if (result.IsSuccess)
+        {
+            await _synchronizationProgressService.UpdateSynchronizationProgress(result, needSendSynchronizationUpdated);
+        }
+
+        _logger.LogInformation(DoneLogTemplate, request.SessionId, actionGroupIds.Count);
+    }
+}
+
+

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/FileOrDirectoryIsDeletedCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/FileOrDirectoryIsDeletedCommandHandler.cs
@@ -1,17 +1,13 @@
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
-using MediatR;
 using Microsoft.Extensions.Logging;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class FileOrDirectoryIsDeletedCommandHandler : IRequestHandler<FileOrDirectoryIsDeletedRequest>
+public class FileOrDirectoryIsDeletedCommandHandler : ActionCompletedHandlerBase<FileOrDirectoryIsDeletedRequest>
 {
-    private readonly ITrackingActionRepository _trackingActionRepository;
-    private readonly ISynchronizationStatusCheckerService _synchronizationStatusCheckerService;
-    private readonly ISynchronizationProgressService _synchronizationProgressService;
-    private readonly ISynchronizationService _synchronizationService;
-    private readonly ILogger<FileOrDirectoryIsDeletedCommandHandler> _logger;
+    protected override string EmptyIdsLog => "FileOrDirectoryIsDeleted: no action group IDs were provided for deletion operation";
+    protected override string DoneLogTemplate => "File or directory is deleted for session {SessionId} with {ActionCount} actions";
 
     public FileOrDirectoryIsDeletedCommandHandler(
         ITrackingActionRepository trackingActionRepository,
@@ -19,51 +15,7 @@ public class FileOrDirectoryIsDeletedCommandHandler : IRequestHandler<FileOrDire
         ISynchronizationProgressService synchronizationProgressService,
         ISynchronizationService synchronizationService,
         ILogger<FileOrDirectoryIsDeletedCommandHandler> logger)
+        : base(trackingActionRepository, synchronizationStatusCheckerService, synchronizationProgressService, synchronizationService, logger)
     {
-        _trackingActionRepository = trackingActionRepository;
-        _synchronizationStatusCheckerService = synchronizationStatusCheckerService;
-        _synchronizationProgressService = synchronizationProgressService;
-        _synchronizationService = synchronizationService;
-        _logger = logger;
-    }
-    
-    public async Task Handle(FileOrDirectoryIsDeletedRequest request, CancellationToken cancellationToken)
-    {
-        if (request.ActionsGroupIds.Count == 0)
-        {
-            _logger.LogInformation("FileOrDirectoryIsDeleted: no action group IDs were provided for deletion operation");
-            return;
-        }
-        
-        bool needSendSynchronizationUpdated = false;
-        
-        var result = await _trackingActionRepository.AddOrUpdate(request.SessionId, request.ActionsGroupIds, (trackingAction, synchronization) =>
-        {
-            if (!_synchronizationStatusCheckerService.CheckSynchronizationCanBeUpdated(synchronization))
-            {
-                return false;
-            }
-            
-            bool wasTrackingActionFinished = trackingAction.IsFinished;
-            
-            trackingAction.AddSuccessOnTarget(request.Client.ClientInstanceId);
-            
-            if (!wasTrackingActionFinished && trackingAction.IsFinished)
-            {
-                synchronization.Progress.FinishedActionsCount += 1;
-            }
-            
-            needSendSynchronizationUpdated = _synchronizationService.CheckSynchronizationIsFinished(synchronization);
-
-            return true;
-        });
-
-        if (result.IsSuccess)
-        {
-            await _synchronizationProgressService.UpdateSynchronizationProgress(result, needSendSynchronizationUpdated);
-        }
-        
-        _logger.LogInformation("File or directory is deleted for session {SessionId} with {ActionCount} actions", 
-            request.SessionId, request.ActionsGroupIds.Count);
     }
 }

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/FileOrDirectoryIsDeletedRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/FileOrDirectoryIsDeletedRequest.cs
@@ -1,9 +1,8 @@
 using ByteSync.ServerCommon.Business.Auth;
-using MediatR;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class FileOrDirectoryIsDeletedRequest : IRequest
+public class FileOrDirectoryIsDeletedRequest : IActionCompletedRequest
 {
     public FileOrDirectoryIsDeletedRequest(string sessionId, Client client, List<string> actionsGroupIds)
     {

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/IActionCompletedRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/IActionCompletedRequest.cs
@@ -1,0 +1,11 @@
+using ByteSync.ServerCommon.Business.Auth;
+using MediatR;
+
+namespace ByteSync.ServerCommon.Commands.Synchronizations;
+
+public interface IActionCompletedRequest : IRequest
+{
+    string SessionId { get; }
+    Client Client { get; }
+    List<string> ActionsGroupIds { get; }
+}

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/IActionErrorRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/IActionErrorRequest.cs
@@ -1,0 +1,10 @@
+using ByteSync.ServerCommon.Business.Auth;
+using MediatR;
+
+namespace ByteSync.ServerCommon.Commands.Synchronizations;
+
+public interface IActionErrorRequest : IRequest
+{
+    string SessionId { get; }
+    Client Client { get; }
+}

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/MemberHasFinishedCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/MemberHasFinishedCommandHandler.cs
@@ -26,7 +26,7 @@ public class MemberHasFinishedCommandHandler : IRequestHandler<MemberHasFinished
     
     public async Task Handle(MemberHasFinishedRequest request, CancellationToken cancellationToken)
     {
-        bool needSendSynchronizationUpdated = false;
+        var needSendSynchronizationUpdated = false;
         
         var result = await _synchronizationRepository.UpdateIfExists(request.SessionId, synchronizationEntity =>
         {

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/RequestSynchronizationAbortCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/RequestSynchronizationAbortCommandHandler.cs
@@ -33,8 +33,8 @@ public class RequestSynchronizationAbortCommandHandler : IRequestHandler<Request
                 return false;
             }
 
-            bool isDateUpdated = false;
-            bool isRequesterAdded = false;
+            var isDateUpdated = false;
+            var isRequesterAdded = false;
 
             if (synchronizationEntity.AbortRequestedOn == null)
             {

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorCommandHandler.cs
@@ -1,17 +1,13 @@
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
-using MediatR;
 using Microsoft.Extensions.Logging;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class SynchronizationErrorCommandHandler : IRequestHandler<SynchronizationErrorRequest>
+public class SynchronizationErrorCommandHandler : ErrorOccurredHandlerBase<SynchronizationErrorRequest>
 {
-    private readonly ITrackingActionRepository _trackingActionRepository;
-    private readonly ISynchronizationStatusCheckerService _synchronizationStatusCheckerService;
-    private readonly ISynchronizationProgressService _synchronizationProgressService;
-    private readonly ISynchronizationService _synchronizationService;
-    private readonly ILogger<SynchronizationErrorCommandHandler> _logger;
+    protected override string EmptyIdsLog => "SynchronizationError: no action group IDs were provided";
+    protected override string DoneLogTemplate => "Synchronization error reported for session {SessionId} with {ActionCount} actions";
 
     public SynchronizationErrorCommandHandler(
         ITrackingActionRepository trackingActionRepository,
@@ -19,70 +15,12 @@ public class SynchronizationErrorCommandHandler : IRequestHandler<Synchronizatio
         ISynchronizationProgressService synchronizationProgressService,
         ISynchronizationService synchronizationService,
         ILogger<SynchronizationErrorCommandHandler> logger)
+        : base(trackingActionRepository, synchronizationStatusCheckerService, synchronizationProgressService, synchronizationService, logger)
     {
-        _trackingActionRepository = trackingActionRepository;
-        _synchronizationStatusCheckerService = synchronizationStatusCheckerService;
-        _synchronizationProgressService = synchronizationProgressService;
-        _synchronizationService = synchronizationService;
-        _logger = logger;
     }
-    
-    public async Task Handle(SynchronizationErrorRequest request, CancellationToken cancellationToken)
+
+    protected override List<string>? GetActionsGroupIds(SynchronizationErrorRequest request)
     {
-        if (request.SharedFileDefinition.ActionsGroupIds?.Count == 0)
-        {
-            _logger.LogInformation("SynchronizationError: no action group IDs were provided");
-            return;
-        }
-        
-        bool needSendSynchronizationUpdated = false;
-        
-        var result = await _trackingActionRepository.AddOrUpdate(request.SessionId, request.SharedFileDefinition.ActionsGroupIds!, (trackingAction, synchronization) =>
-        {
-            if (!_synchronizationStatusCheckerService.CheckSynchronizationCanBeUpdated(synchronization))
-            {
-                return false;
-            }
-            
-            bool wasTrackingActionFinished = trackingAction.IsFinished;
-            bool isNewError = !trackingAction.IsError;
-            
-            if (trackingAction.SourceClientInstanceId == request.Client.ClientInstanceId)
-            {
-                trackingAction.IsSourceSuccess = false;
-            }
-            else
-            {
-                if (trackingAction.TargetClientInstanceIds.Contains(request.Client.ClientInstanceId))
-                {
-                    trackingAction.AddErrorOnTarget(request.Client.ClientInstanceId);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Client is not a target of the action");
-                }
-            }
-            
-            if (isNewError)
-            {
-                synchronization.Progress.ErrorsCount += 1;
-            }
-            if (!wasTrackingActionFinished && trackingAction.IsFinished)
-            {
-                synchronization.Progress.FinishedActionsCount += 1;
-            }
-            
-            needSendSynchronizationUpdated = _synchronizationService.CheckSynchronizationIsFinished(synchronization);
-
-            return true;
-        });
-
-        if (result.IsSuccess)
-        {
-            await _synchronizationProgressService.UpdateSynchronizationProgress(result, needSendSynchronizationUpdated);
-        }
-        
-        _logger.LogInformation("Synchronization error reported for session {SessionId} with {ActionCount} actions", 
-            request.SessionId, request.SharedFileDefinition.ActionsGroupIds?.Count ?? 0);
+        return request.SharedFileDefinition.ActionsGroupIds;
     }
 }

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorRequest.cs
@@ -1,10 +1,9 @@
 using ByteSync.Common.Business.SharedFiles;
 using ByteSync.ServerCommon.Business.Auth;
-using MediatR;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class SynchronizationErrorRequest : IRequest
+public class SynchronizationErrorRequest : IActionErrorRequest
 {
     public SynchronizationErrorRequest(string sessionId, Client client, SharedFileDefinition sharedFileDefinition)
     {

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorsCommandHandler.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorsCommandHandler.cs
@@ -1,17 +1,13 @@
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
-using MediatR;
 using Microsoft.Extensions.Logging;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class SynchronizationErrorsCommandHandler : IRequestHandler<SynchronizationErrorsRequest>
+public class SynchronizationErrorsCommandHandler : ErrorOccurredHandlerBase<SynchronizationErrorsRequest>
 {
-    private readonly ITrackingActionRepository _trackingActionRepository;
-    private readonly ISynchronizationStatusCheckerService _synchronizationStatusCheckerService;
-    private readonly ISynchronizationProgressService _synchronizationProgressService;
-    private readonly ISynchronizationService _synchronizationService;
-    private readonly ILogger<SynchronizationErrorsCommandHandler> _logger;
+    protected override string EmptyIdsLog => "SynchronizationError: no action group IDs were provided";
+    protected override string DoneLogTemplate => "Synchronization errors reported for session {SessionId} with {ActionCount} actions";
 
     public SynchronizationErrorsCommandHandler(
         ITrackingActionRepository trackingActionRepository,
@@ -19,70 +15,12 @@ public class SynchronizationErrorsCommandHandler : IRequestHandler<Synchronizati
         ISynchronizationProgressService synchronizationProgressService,
         ISynchronizationService synchronizationService,
         ILogger<SynchronizationErrorsCommandHandler> logger)
+        : base(trackingActionRepository, synchronizationStatusCheckerService, synchronizationProgressService, synchronizationService, logger)
     {
-        _trackingActionRepository = trackingActionRepository;
-        _synchronizationStatusCheckerService = synchronizationStatusCheckerService;
-        _synchronizationProgressService = synchronizationProgressService;
-        _synchronizationService = synchronizationService;
-        _logger = logger;
     }
-    
-    public async Task Handle(SynchronizationErrorsRequest request, CancellationToken cancellationToken)
+
+    protected override List<string>? GetActionsGroupIds(SynchronizationErrorsRequest request)
     {
-        if (request.ActionsGroupIds.Count == 0)
-        {
-            _logger.LogInformation("SynchronizationError: no action group IDs were provided");
-            return;
-        }
-        
-        bool needSendSynchronizationUpdated = false;
-        
-        var result = await _trackingActionRepository.AddOrUpdate(request.SessionId, request.ActionsGroupIds, (trackingAction, synchronization) =>
-        {
-            if (!_synchronizationStatusCheckerService.CheckSynchronizationCanBeUpdated(synchronization))
-            {
-                return false;
-            }
-            
-            bool wasTrackingActionFinished = trackingAction.IsFinished;
-            bool isNewError = !trackingAction.IsError;
-            
-            if (trackingAction.SourceClientInstanceId == request.Client.ClientInstanceId)
-            {
-                trackingAction.IsSourceSuccess = false;
-            }
-            else
-            {
-                if (trackingAction.TargetClientInstanceIds.Contains(request.Client.ClientInstanceId))
-                {
-                    trackingAction.AddErrorOnTarget(request.Client.ClientInstanceId);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Client is not a target of the action");
-                }
-            }
-            
-            if (isNewError)
-            {
-                synchronization.Progress.ErrorsCount += 1;
-            }
-            if (!wasTrackingActionFinished && trackingAction.IsFinished)
-            {
-                synchronization.Progress.FinishedActionsCount += 1;
-            }
-            
-            needSendSynchronizationUpdated = _synchronizationService.CheckSynchronizationIsFinished(synchronization);
-
-            return true;
-        });
-
-        if (result.IsSuccess)
-        {
-            await _synchronizationProgressService.UpdateSynchronizationProgress(result, needSendSynchronizationUpdated);
-        }
-        
-        _logger.LogInformation("Synchronization errors reported for session {SessionId} with {ActionCount} actions", 
-            request.SessionId, request.ActionsGroupIds.Count);
+        return request.ActionsGroupIds;
     }
 }

--- a/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorsRequest.cs
+++ b/src/ByteSync.ServerCommon/Commands/Synchronizations/SynchronizationErrorsRequest.cs
@@ -1,9 +1,8 @@
 using ByteSync.ServerCommon.Business.Auth;
-using MediatR;
 
 namespace ByteSync.ServerCommon.Commands.Synchronizations;
 
-public class SynchronizationErrorsRequest : IRequest
+public class SynchronizationErrorsRequest : IActionErrorRequest
 {
     public SynchronizationErrorsRequest(string sessionId, Client client, List<string> actionsGroupIds)
     {

--- a/src/ByteSync.ServerCommon/Repositories/SynchronizationRepository.cs
+++ b/src/ByteSync.ServerCommon/Repositories/SynchronizationRepository.cs
@@ -33,7 +33,9 @@ public class SynchronizationRepository : BaseRepository<SynchronizationEntity>, 
                 var trackingActionEntity = new TrackingActionEntity
                 {
                     ActionsGroupId = groupDefinition.ActionsGroupId,
-                    SourceClientInstanceId = groupDefinition.Source,
+                    SourceClientInstanceId = groupDefinition.IsInitialOperatingOnSourceNeeded 
+                        ? groupDefinition.Source 
+                        : null,
                     TargetClientInstanceIds = [..groupDefinition.Targets],
                     Size = groupDefinition.Size,
                 };

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/Upload_SliceAndParallelism_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/Upload_SliceAndParallelism_Tests.cs
@@ -1,0 +1,245 @@
+using Autofac;
+using ByteSync.Business.Communications.Transfers;
+using ByteSync.Client.IntegrationTests.TestHelpers;
+using ByteSync.Common.Business.Communications.Transfers;
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.DependencyInjection;
+using ByteSync.Interfaces.Controls.Communications;
+using ByteSync.Interfaces.Controls.Communications.Http;
+using ByteSync.Interfaces.Factories;
+using ByteSync.Interfaces.Repositories;
+using ByteSync.Services.Communications.Transfers.Uploading;
+using FluentAssertions;
+
+namespace ByteSync.Client.IntegrationTests.Services.Communications.Transfers;
+
+public class Upload_SliceAndParallelism_Tests
+{
+    private ILifetimeScope _clientScope = null!;
+
+    private class TestUploadStrategy : IUploadStrategy
+    {
+        private static readonly object Sync = new object();
+        public static readonly Dictionary<string, List<(int PartNumber, long Bytes, int TaskId)>> Records = new();
+
+        public Task<UploadFileResponse> UploadAsync(FileUploaderSlice slice, FileStorageLocation storageLocation, CancellationToken cancellationToken)
+        {
+            var taskId = Environment.CurrentManagedThreadId;
+            lock (Sync)
+            {
+                var sharedId = storageLocation.Url; // We will encode SharedFileDefinition.Id in the URL via TestApiClient
+                if (!Records.ContainsKey(sharedId))
+                {
+                    Records[sharedId] = new List<(int, long, int)>();
+                }
+                Records[sharedId].Add((slice.PartNumber, slice.MemoryStream?.Length ?? 0L, taskId));
+            }
+            return Task.FromResult(UploadFileResponse.Success(200));
+        }
+    }
+
+    private class TestFileTransferApiClient : IFileTransferApiClient
+    {
+        public Task<string> GetUploadFileUrl(TransferParameters transferParameters)
+        {
+            // Use SharedFileDefinition.Id as a pseudo URL to key records
+            return Task.FromResult(transferParameters.SharedFileDefinition.Id);
+        }
+
+        public async Task<FileStorageLocation> GetUploadFileStorageLocation(TransferParameters transferParameters)
+        {
+            var url = await GetUploadFileUrl(transferParameters);
+            return new FileStorageLocation(url, StorageProvider.AzureBlobStorage);
+        }
+
+        public Task<string> GetDownloadFileUrl(TransferParameters transferParameters) => Task.FromResult(string.Empty);
+        public Task<FileStorageLocation> GetDownloadFileStorageLocation(TransferParameters transferParameters) => Task.FromResult(new FileStorageLocation(string.Empty, StorageProvider.AzureBlobStorage));
+        public Task AssertFilePartIsUploaded(TransferParameters transferParameters) => Task.CompletedTask;
+        public Task AssertUploadIsFinished(TransferParameters transferParameters) => Task.CompletedTask;
+        public Task AssertFilePartIsDownloaded(TransferParameters transferParameters) => Task.CompletedTask;
+        public Task AssertDownloadIsFinished(TransferParameters transferParameters) => Task.CompletedTask;
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        if (ByteSync.Services.ContainerProvider.Container == null)
+        {
+            ServiceRegistrar.RegisterComponents();
+        }
+
+        _clientScope = ByteSync.Services.ContainerProvider.Container!.BeginLifetimeScope(b =>
+        {
+            // Override HTTP client with local test client and upload strategy
+            b.RegisterType<TestFileTransferApiClient>().As<IFileTransferApiClient>().SingleInstance();
+            b.RegisterType<TestUploadStrategy>().Keyed<IUploadStrategy>(StorageProvider.AzureBlobStorage).SingleInstance();
+        });
+
+        // Set AES key for encryption used by SlicerEncrypter
+        using var scope = _clientScope.BeginLifetimeScope();
+        var cloudSessionConnectionRepository = scope.Resolve<ICloudSessionConnectionRepository>();
+        cloudSessionConnectionRepository.SetAesEncryptionKey(AesGenerator.GenerateKey());
+
+        // Clear previous records
+        lock (TestUploadStrategy.Records)
+        {
+            TestUploadStrategy.Records.Clear();
+        }
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _clientScope?.Dispose();
+    }
+
+    private static SharedFileDefinition BuildShared(string? id = null)
+    {
+        return new SharedFileDefinition
+        {
+            Id = id ?? Guid.NewGuid().ToString("N"),
+            SessionId = "itests-" + Guid.NewGuid().ToString("N"),
+            ClientInstanceId = Guid.NewGuid().ToString("N"),
+            SharedFileType = SharedFileTypes.FullSynchronization,
+            IV = AesGenerator.GenerateIV()
+        };
+    }
+
+    [Test]
+    public async Task Upload_OneSmallFile_FixedSliceLen_FixedParallel_ShouldHaveOneTaskAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared = BuildShared("small1");
+
+        var tempFile = Path.GetTempFileName();
+        var inputContent = new string('a', 512); // smaller than slice
+        await File.WriteAllTextAsync(tempFile, inputContent);
+
+        var uploader = uploaderFactory.Build(tempFile, shared) as FileUploader;
+        uploader!.MaxSliceLength = 1024; // fixed slice length
+
+        await uploader.Upload();
+
+        TestUploadStrategy.Records.ContainsKey(shared.Id).Should().BeTrue();
+        var recs = TestUploadStrategy.Records[shared.Id];
+        recs.Count.Should().Be(1); // only one slice/task
+        recs.Select(r => r.TaskId).Distinct().Count().Should().Be(1); // one worker involved
+        shared.UploadedFileLength.Should().Be(inputContent.Length); // full length transferred
+    }
+
+    [Test]
+    public async Task Upload_OneBigFile_ThreeSlices_Parallel1_ShouldHaveThreeTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared = BuildShared("big1");
+
+        var tempFile = Path.GetTempFileName();
+        var sliceLength = 1000;
+        var inputContent = new string('b', sliceLength * 3 + 1); // > 3x slice length => 4 slices
+        await File.WriteAllTextAsync(tempFile, inputContent);
+
+        var uploader = uploaderFactory.Build(tempFile, shared) as FileUploader;
+        uploader!.MaxSliceLength = sliceLength; // fixed slice length
+
+        await uploader.Upload();
+
+        var recs = TestUploadStrategy.Records[shared.Id];
+        recs.Count.Should().Be(4);
+        recs.Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        shared.UploadedFileLength.Should().Be(inputContent.Length);
+    }
+
+    [Test]
+    public async Task Upload_OneBigFile_ThreeSlices_Parallel3_ShouldHaveThreeTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared = BuildShared("big3");
+
+        var tempFile = Path.GetTempFileName();
+        var sliceLength = 1000;
+        var inputContent = new string('c', sliceLength * 3 + 5); // > 3x slice length => 4 slices
+        await File.WriteAllTextAsync(tempFile, inputContent);
+
+        var uploader = uploaderFactory.Build(tempFile, shared) as FileUploader;
+        uploader!.MaxSliceLength = sliceLength;
+
+        await uploader.Upload();
+
+        var recs = TestUploadStrategy.Records[shared.Id];
+        recs.Count.Should().Be(4);
+        recs.Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        shared.UploadedFileLength.Should().Be(inputContent.Length);
+    }
+
+    [Test]
+    public async Task Upload_TwoSmallFiles_FixedSliceLen_FixedParallel_ShouldHaveTwoTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared1 = BuildShared("s1");
+        var shared2 = BuildShared("s2");
+
+        var tempFile1 = Path.GetTempFileName();
+        var tempFile2 = Path.GetTempFileName();
+        var c1 = new string('x', 400);
+        var c2 = new string('y', 700);
+        await File.WriteAllTextAsync(tempFile1, c1);
+        await File.WriteAllTextAsync(tempFile2, c2);
+
+        var uploader1 = uploaderFactory.Build(tempFile1, shared1) as FileUploader;
+        var uploader2 = uploaderFactory.Build(tempFile2, shared2) as FileUploader;
+        uploader1!.MaxSliceLength = 1024;
+        uploader2!.MaxSliceLength = 1024;
+
+        await uploader1.Upload();
+        await uploader2.Upload();
+
+        TestUploadStrategy.Records[shared1.Id].Count.Should().Be(1);
+        TestUploadStrategy.Records[shared2.Id].Count.Should().Be(1);
+        shared1.UploadedFileLength.Should().Be(c1.Length);
+        shared2.UploadedFileLength.Should().Be(c2.Length);
+    }
+
+    [Test]
+    public async Task Upload_TwoBigFiles_ThreeSlicesEach_Parallel3_ShouldHaveThreeTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared1 = BuildShared("b1");
+        var shared2 = BuildShared("b2");
+
+        var sliceLength = 2560;
+        var c1 = new string('m', sliceLength * 3 + 3); // > 3x slice length => 4 slices
+        var c2 = new string('n', sliceLength * 3 + 7); // > 3x slice length => 4 slices
+
+        var tempFile1 = Path.GetTempFileName();
+        var tempFile2 = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tempFile1, c1);
+        await File.WriteAllTextAsync(tempFile2, c2);
+
+        var uploader1 = uploaderFactory.Build(tempFile1, shared1) as FileUploader;
+        var uploader2 = uploaderFactory.Build(tempFile2, shared2) as FileUploader;
+        uploader1!.MaxSliceLength = sliceLength;
+        uploader2!.MaxSliceLength = sliceLength;
+
+        await uploader1.Upload();
+        await uploader2.Upload();
+
+        TestUploadStrategy.Records[shared1.Id].Count.Should().Be(4);
+        TestUploadStrategy.Records[shared2.Id].Count.Should().Be(4);
+        TestUploadStrategy.Records[shared1.Id].Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        TestUploadStrategy.Records[shared2.Id].Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        shared1.UploadedFileLength.Should().Be(c1.Length);
+        shared2.UploadedFileLength.Should().Be(c2.Length);
+    }
+}
+
+

--- a/tests/ByteSync.Client.IntegrationTests/Services/Themes/ThemeFactory_HeadlessTests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Themes/ThemeFactory_HeadlessTests.cs
@@ -1,0 +1,73 @@
+using Autofac;
+using Avalonia;
+using Avalonia.Styling;
+using ByteSync.Client.IntegrationTests.TestHelpers;
+using ByteSync.DependencyInjection;
+using ByteSync.Interfaces.Controls.Themes;
+
+namespace ByteSync.Client.IntegrationTests.Services.Themes;
+
+public class ThemeFactory_HeadlessTests : HeadlessIntegrationTest
+{
+    private ILifetimeScope _scope = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (ByteSync.Services.ContainerProvider.Container == null)
+        {
+            ServiceRegistrar.RegisterComponents();
+        }
+
+        _scope = ByteSync.Services.ContainerProvider.Container!.BeginLifetimeScope();
+
+        // Ensure clean state between tests: ThemeService is a singleton; avoid duplicates
+        var themeService = _scope.Resolve<IThemeService>();
+        themeService.AvailableThemes.Clear();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _scope.Dispose();
+    }
+
+    [Test]
+    public void BuildThemes_registers_all_and_applies_default()
+    {
+        var themeFactory = _scope.Resolve<IThemeFactory>();
+        var themeService = _scope.Resolve<IThemeService>();
+
+        ExecuteOnUiThread(async () =>
+        {
+            themeFactory.BuildThemes();
+            await Task.CompletedTask;
+        }).Wait();
+
+        Assert.That(themeService.AvailableThemes.Count, Is.EqualTo(24));
+        Assert.That(Application.Current!.RequestedThemeVariant, Is.EqualTo(ThemeVariant.Light));
+
+        var brush = themeService.GetBrush("SystemAccentColor");
+        Assert.That(brush, Is.Not.Null);
+    }
+
+    [Test]
+    public void SelectTheme_switches_variant_and_updates_resources()
+    {
+        var themeFactory = _scope.Resolve<IThemeFactory>();
+        var themeService = _scope.Resolve<IThemeService>();
+
+        ExecuteOnUiThread(async () =>
+        {
+            themeFactory.BuildThemes();
+            themeService.SelectTheme("Blue1", isDarkMode: true);
+            await Task.CompletedTask;
+        }).Wait();
+
+        Assert.That(Application.Current!.RequestedThemeVariant, Is.EqualTo(ThemeVariant.Dark));
+        Assert.That(themeService.GetBrush("BsAccentButtonBackGround"), Is.Not.Null);
+    }
+}
+
+

--- a/tests/ByteSync.Client.Tests/Business/Communications/Transfers/FileUploaderSliceTests.cs
+++ b/tests/ByteSync.Client.Tests/Business/Communications/Transfers/FileUploaderSliceTests.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using System.IO;
 using ByteSync.Business.Communications.Transfers;
 using FluentAssertions;
 

--- a/tests/ByteSync.Client.Tests/Business/Communications/Transfers/UploadProgressStateTests.cs
+++ b/tests/ByteSync.Client.Tests/Business/Communications/Transfers/UploadProgressStateTests.cs
@@ -19,7 +19,7 @@ public class UploadProgressStateTests
         progressState.TotalUploadedSlices.Should().Be(0);
         progressState.ConcurrentUploads.Should().Be(0);
         progressState.MaxConcurrentUploads.Should().Be(0);
-        progressState.LastException.Should().BeNull();
+        progressState.Exceptions.Should().BeEmpty();
     }
 
     [Test]
@@ -83,16 +83,15 @@ public class UploadProgressStateTests
     }
 
     [Test]
-    public void LastException_ShouldBeGettableAndSettable()
+    public void Exceptions_ShouldBeGettableAndSettable()
     {
         // Arrange
         var progressState = new UploadProgressState();
         var expectedException = new Exception("Test exception");
 
         // Act
-        progressState.LastException = expectedException;
-        var result = progressState.LastException;
-
+        progressState.Exceptions.Add(expectedException);
+        var result = progressState.Exceptions[0];
         // Assert
         result.Should().Be(expectedException);
     }
@@ -238,37 +237,38 @@ public class UploadProgressStateTests
     }
 
     [Test]
-    public void LastException_WithNullValue_ShouldWork()
+    public void Exceptions_WithNullValue_ShouldWork()
     {
         // Arrange
         var progressState = new UploadProgressState();
 
         // Act
-        progressState.LastException = null;
-        var result = progressState.LastException;
+        
+        progressState.Exceptions.Add(null!);
+        var result = progressState.Exceptions[0];
 
         // Assert
         result.Should().BeNull();
     }
 
     [Test]
-    public void LastException_WithDifferentExceptionTypes_ShouldWork()
+    public void Exceptions_WithDifferentExceptionTypes_ShouldWork()
     {
         // Arrange
         var progressState = new UploadProgressState();
 
         // Act & Assert
         var invalidOperationException = new InvalidOperationException("Invalid operation");
-        progressState.LastException = invalidOperationException;
-        progressState.LastException.Should().Be(invalidOperationException);
+        progressState.Exceptions.Add(invalidOperationException);
+        progressState.Exceptions[0].Should().Be(invalidOperationException);
 
         var argumentException = new ArgumentException("Invalid argument");
-        progressState.LastException = argumentException;
-        progressState.LastException.Should().Be(argumentException);
+        progressState.Exceptions.Add(argumentException);
+        progressState.Exceptions[1].Should().Be(argumentException);
 
         var timeoutException = new TimeoutException("Operation timed out");
-        progressState.LastException = timeoutException;
-        progressState.LastException.Should().Be(timeoutException);
+        progressState.Exceptions.Add(timeoutException);
+        progressState.Exceptions[2].Should().Be(timeoutException);
     }
 
     [Test]
@@ -282,14 +282,14 @@ public class UploadProgressStateTests
         progressState.TotalUploadedSlices = 5;
         progressState.ConcurrentUploads = 3;
         progressState.MaxConcurrentUploads = 8;
-        progressState.LastException = new Exception("Test");
+        progressState.Exceptions.Add(new Exception("Test"));
 
         // Assert
         progressState.TotalCreatedSlices.Should().Be(10);
         progressState.TotalUploadedSlices.Should().Be(5);
         progressState.ConcurrentUploads.Should().Be(3);
         progressState.MaxConcurrentUploads.Should().Be(8);
-        progressState.LastException.Should().NotBeNull();
+        progressState.Exceptions.Should().NotBeNull();
     }
 
     [Test]
@@ -326,7 +326,7 @@ public class UploadProgressStateTests
     }
 
     [Test]
-    public void LastException_ShouldPreserveInnerException()
+    public void Exceptions_ShouldPreserveInnerException()
     {
         // Arrange
         var progressState = new UploadProgressState();
@@ -334,11 +334,11 @@ public class UploadProgressStateTests
         var outerException = new Exception("Outer exception", innerException);
 
         // Act
-        progressState.LastException = outerException;
+        progressState.Exceptions.Add(outerException);
 
         // Assert
-        progressState.LastException.Should().Be(outerException);
-        progressState.LastException!.InnerException.Should().Be(innerException);
+        progressState.Exceptions[0].Should().Be(outerException);
+        progressState.Exceptions[0].InnerException.Should().Be(innerException);
     }
 
     [Test]
@@ -350,11 +350,11 @@ public class UploadProgressStateTests
         var exception = new Exception(exceptionMessage);
 
         // Act
-        progressState.LastException = exception;
+        progressState.Exceptions.Add(exception);
 
         // Assert
-        progressState.LastException.Should().Be(exception);
-        progressState.LastException!.Message.Should().Be(exceptionMessage);
+        progressState.Exceptions[0].Should().Be(exception);
+        progressState.Exceptions[0].Message.Should().Be(exceptionMessage);
     }
 
     [Test]
@@ -373,10 +373,10 @@ public class UploadProgressStateTests
         }
 
         // Act
-        progressState.LastException = exception;
+        progressState.Exceptions.Add(exception);
 
         // Assert
-        progressState.LastException.Should().Be(exception);
-        progressState.LastException!.StackTrace.Should().NotBeNullOrEmpty();
+        progressState.Exceptions[0].Should().Be(exception);
+        progressState.Exceptions[0].StackTrace.Should().NotBeNullOrEmpty();
     }
 } 

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileSlicerMetricsTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileSlicerMetricsTests.cs
@@ -13,14 +13,14 @@ namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
 [TestFixture]
 public class FileSlicerMetricsTests
 {
-    private Mock<ISlicerEncrypter> _mockSlicerEncrypter;
-    private Mock<ILogger<FileSlicer>> _mockLogger;
-    private Channel<FileUploaderSlice> _availableSlices;
-    private SemaphoreSlim _semaphoreSlim;
-    private ManualResetEvent _exceptionOccurred;
-    private FileSlicer _fileSlicer;
-    private SharedFileDefinition _sharedFileDefinition;
-    private UploadProgressState _progressState;
+    private Mock<ISlicerEncrypter> _mockSlicerEncrypter = null!;
+    private Mock<ILogger<FileSlicer>> _mockLogger = null!;
+    private Channel<FileUploaderSlice> _availableSlices = null!;
+    private SemaphoreSlim _semaphoreSlim = null!;
+    private ManualResetEvent _exceptionOccurred = null!;
+    private FileSlicer _fileSlicer = null!;
+    private SharedFileDefinition _sharedFileDefinition = null!;
+    private UploadProgressState _progressState = null!;
 
     [SetUp]
     public void SetUp()
@@ -51,8 +51,8 @@ public class FileSlicerMetricsTests
     [TearDown]
     public void TearDown()
     {
-        _exceptionOccurred?.Dispose();
-        _semaphoreSlim?.Dispose();
+        _exceptionOccurred.Dispose();
+        _semaphoreSlim.Dispose();
     }
 
     [Test]
@@ -79,7 +79,6 @@ public class FileSlicerMetricsTests
 
         await _fileSlicer.SliceAndEncryptAsync(_sharedFileDefinition, _progressState);
 
-        _progressState.LastException.Should().NotBeNull();
         _progressState.Exceptions.Count.Should().Be(1);
     }
 }

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileSlicerMetricsTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileSlicerMetricsTests.cs
@@ -1,0 +1,87 @@
+using System.Threading.Channels;
+using ByteSync.Business.Communications.Transfers;
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.Interfaces.Controls.Encryptions;
+using ByteSync.Services.Communications.Transfers.Uploading;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
+
+[TestFixture]
+public class FileSlicerMetricsTests
+{
+    private Mock<ISlicerEncrypter> _mockSlicerEncrypter;
+    private Mock<ILogger<FileSlicer>> _mockLogger;
+    private Channel<FileUploaderSlice> _availableSlices;
+    private SemaphoreSlim _semaphoreSlim;
+    private ManualResetEvent _exceptionOccurred;
+    private FileSlicer _fileSlicer;
+    private SharedFileDefinition _sharedFileDefinition;
+    private UploadProgressState _progressState;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockSlicerEncrypter = new Mock<ISlicerEncrypter>();
+        _mockLogger = new Mock<ILogger<FileSlicer>>();
+        _availableSlices = Channel.CreateBounded<FileUploaderSlice>(8);
+        _semaphoreSlim = new SemaphoreSlim(1, 1);
+        _exceptionOccurred = new ManualResetEvent(false);
+
+        _fileSlicer = new FileSlicer(
+            _mockSlicerEncrypter.Object,
+            _availableSlices,
+            _semaphoreSlim,
+            _exceptionOccurred,
+            _mockLogger.Object);
+
+        _sharedFileDefinition = new SharedFileDefinition
+        {
+            Id = "test-file-id",
+            SessionId = "test-session-id",
+            UploadedFileLength = 1024
+        };
+
+        _progressState = new UploadProgressState();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _exceptionOccurred?.Dispose();
+        _semaphoreSlim?.Dispose();
+    }
+
+    [Test]
+    public async Task SliceAndEncryptAsync_ShouldAccumulateCreatedBytes()
+    {
+        var slice1 = new FileUploaderSlice(1, new MemoryStream(new byte[100]));
+        var slice2 = new FileUploaderSlice(2, new MemoryStream(new byte[200]));
+
+        _mockSlicerEncrypter.SetupSequence(x => x.SliceAndEncrypt())
+            .ReturnsAsync(slice1)
+            .ReturnsAsync(slice2)
+            .ReturnsAsync((FileUploaderSlice?)null);
+
+        await _fileSlicer.SliceAndEncryptAsync(_sharedFileDefinition, _progressState);
+
+        _progressState.TotalCreatedSlices.Should().Be(2);
+        _progressState.TotalCreatedBytes.Should().Be(300);
+    }
+
+    [Test]
+    public async Task SliceAndEncryptAsync_OnException_ShouldRecordError()
+    {
+        _mockSlicerEncrypter.Setup(x => x.SliceAndEncrypt()).ThrowsAsync(new Exception("boom"));
+
+        await _fileSlicer.SliceAndEncryptAsync(_sharedFileDefinition, _progressState);
+
+        _progressState.LastException.Should().NotBeNull();
+        _progressState.Exceptions.Count.Should().Be(1);
+    }
+}
+
+

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
@@ -78,8 +78,8 @@ public class FileUploadProcessorTests
         {
             File.Delete(_testFilePath);
         }
-        _testMemoryStream?.Dispose();
-        _semaphoreSlim?.Dispose();
+        _testMemoryStream.Dispose();
+        _semaphoreSlim.Dispose();
     }
 
     [Test]
@@ -206,7 +206,7 @@ public class FileUploadProcessorTests
         // Arrange
         var expectedException = new Exception("Test exception");
         _mockFileSlicer.Setup(x => x.SliceAndEncryptAsync(It.IsAny<SharedFileDefinition>(), It.IsAny<UploadProgressState>(), It.IsAny<int?>()))
-            .Callback<SharedFileDefinition, UploadProgressState, int?>((_, progressState, _) => progressState.LastException = expectedException)
+            .Callback<SharedFileDefinition, UploadProgressState, int?>((_, progressState, _) => progressState.Exceptions.Add(expectedException))
             .Returns(Task.CompletedTask);
 
         // Act & Assert
@@ -231,7 +231,7 @@ public class FileUploadProcessorTests
 
         var expectedException = new Exception("Test exception");
         _mockFileSlicer.Setup(x => x.SliceAndEncryptAsync(It.IsAny<SharedFileDefinition>(), It.IsAny<UploadProgressState>(), It.IsAny<int?>()))
-            .Callback<SharedFileDefinition, UploadProgressState, int?>((_, progressState, _) => progressState.LastException = expectedException)
+            .Callback<SharedFileDefinition, UploadProgressState, int?>((_, progressState, _) => progressState.Exceptions.Add(expectedException))
             .Returns(Task.CompletedTask);
 
         // Act & Assert

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorTests.cs
@@ -14,17 +14,17 @@ namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
 [TestFixture]
 public class FileUploadProcessorTests
 {
-    private Mock<ISlicerEncrypter> _mockSlicerEncrypter;
-    private Mock<ILogger> _mockLogger;
-    private Mock<IFileUploadCoordinator> _mockFileUploadCoordinator;
-    private Mock<IFileSlicer> _mockFileSlicer;
-    private Mock<IFileUploadWorker> _mockFileUploadWorker;
-    private Mock<IFilePartUploadAsserter> _mockFilePartUploadAsserter;
-    private SharedFileDefinition _sharedFileDefinition;
-    private string _testFilePath;
-    private MemoryStream _testMemoryStream;
-    private FileUploadProcessor _fileUploadProcessor;
-    private SemaphoreSlim _semaphoreSlim;
+    private Mock<ISlicerEncrypter> _mockSlicerEncrypter = null!;
+    private Mock<ILogger> _mockLogger = null!;
+    private Mock<IFileUploadCoordinator> _mockFileUploadCoordinator = null!;
+    private Mock<IFileSlicer> _mockFileSlicer = null!;
+    private Mock<IFileUploadWorker> _mockFileUploadWorker = null!;
+    private Mock<IFilePartUploadAsserter> _mockFilePartUploadAsserter = null!;
+    private SharedFileDefinition _sharedFileDefinition = null!;
+    private string _testFilePath = null!;
+    private MemoryStream _testMemoryStream = null!;
+    private FileUploadProcessor _fileUploadProcessor = null!;
+    private SemaphoreSlim _semaphoreSlim = null!;
 
     [SetUp]
     public void SetUp()
@@ -116,7 +116,7 @@ public class FileUploadProcessorTests
         await _fileUploadProcessor.ProcessUpload(_sharedFileDefinition);
 
         // Assert
-        _mockFileUploadWorker.Verify(x => x.UploadAvailableSlicesAsync(It.IsAny<Channel<FileUploaderSlice>>(), It.IsAny<UploadProgressState>()), Times.Exactly(6));
+        _mockFileUploadWorker.Verify(x => x.UploadAvailableSlicesAsync(It.IsAny<Channel<FileUploaderSlice>>(), It.IsAny<UploadProgressState>()), Times.Exactly(2));
     }
 
     [Test]

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadWorkerMetricsTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadWorkerMetricsTests.cs
@@ -1,0 +1,142 @@
+using System.Threading.Channels;
+using Autofac.Features.Indexed;
+using ByteSync.Business.Communications.Transfers;
+using ByteSync.Common.Business.Communications.Transfers;
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.Interfaces;
+using ByteSync.Interfaces.Controls.Communications;
+using ByteSync.Interfaces.Controls.Communications.Http;
+using ByteSync.Services.Communications.Transfers.Uploading;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Polly;
+using Polly.Retry;
+
+namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
+
+[TestFixture]
+public class FileUploadWorkerMetricsTests
+{
+    private Mock<IPolicyFactory> _mockPolicyFactory;
+    private Mock<IFileTransferApiClient> _mockFileTransferApiClient;
+    private Mock<ILogger<FileUploadWorker>> _mockLogger;
+    private Mock<IIndex<StorageProvider, IUploadStrategy>> _mockStrategies;
+    private AsyncRetryPolicy<UploadFileResponse> _policy;
+    private SharedFileDefinition _sharedFileDefinition;
+    private ManualResetEvent _exceptionOccurred;
+    private ManualResetEvent _uploadingIsFinished;
+    private FileUploadWorker _fileUploadWorker;
+    private Channel<FileUploaderSlice> _availableSlices;
+    private UploadProgressState _progressState;
+    private SemaphoreSlim _semaphoreSlim;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockPolicyFactory = new Mock<IPolicyFactory>();
+        _mockFileTransferApiClient = new Mock<IFileTransferApiClient>();
+        _mockLogger = new Mock<ILogger<FileUploadWorker>>();
+        _mockStrategies = new Mock<IIndex<StorageProvider, IUploadStrategy>>();
+
+        _policy = Policy<UploadFileResponse>
+            .HandleResult(x => !x.IsSuccess)
+            .Or<Exception>()
+            .RetryAsync(0);
+
+        _sharedFileDefinition = new SharedFileDefinition
+        {
+            Id = "test-file-id",
+            SessionId = "test-session-id",
+            UploadedFileLength = 1024
+        };
+
+        _semaphoreSlim = new SemaphoreSlim(1, 1);
+        _exceptionOccurred = new ManualResetEvent(false);
+        _uploadingIsFinished = new ManualResetEvent(false);
+        _availableSlices = Channel.CreateBounded<FileUploaderSlice>(8);
+        _progressState = new UploadProgressState();
+
+        _fileUploadWorker = new FileUploadWorker(
+            _mockPolicyFactory.Object,
+            _mockFileTransferApiClient.Object,
+            _sharedFileDefinition,
+            _semaphoreSlim,
+            _exceptionOccurred,
+            _mockStrategies.Object,
+            _uploadingIsFinished,
+            _mockLogger.Object);
+
+        _mockPolicyFactory.Setup(x => x.BuildFileUploadPolicy()).Returns(_policy);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _exceptionOccurred?.Dispose();
+        _uploadingIsFinished?.Dispose();
+        _semaphoreSlim?.Dispose();
+    }
+
+    [Test]
+    public async Task UploadAvailableSlicesAsync_ShouldTrackBytesAndConcurrency()
+    {
+        var slice = new FileUploaderSlice(1, new MemoryStream(new byte[256]));
+        var storageProvider = StorageProvider.AzureBlobStorage;
+        var mockUploadStrategy = new Mock<IUploadStrategy>();
+        var mockUploadLocation = new FileStorageLocation("https://test.example.com/upload", storageProvider);
+
+        mockUploadStrategy.Setup(x => x.UploadAsync(It.IsAny<FileUploaderSlice>(), It.IsAny<FileStorageLocation>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UploadFileResponse.Success(200));
+
+        _mockStrategies.Setup(x => x[storageProvider]).Returns(mockUploadStrategy.Object);
+        _mockFileTransferApiClient.Setup(x => x.GetUploadFileStorageLocation(It.IsAny<TransferParameters>()))
+            .ReturnsAsync(mockUploadLocation);
+        _mockFileTransferApiClient.Setup(x => x.AssertFilePartIsUploaded(It.IsAny<TransferParameters>()))
+            .Returns(Task.CompletedTask);
+
+        await _availableSlices.Writer.WriteAsync(slice);
+        _availableSlices.Writer.Complete();
+
+        await _fileUploadWorker.UploadAvailableSlicesAsync(_availableSlices, _progressState);
+
+        _progressState.TotalUploadedSlices.Should().Be(1);
+        _progressState.TotalUploadedBytes.Should().Be(256);
+        _progressState.MaxConcurrentUploads.Should().BeGreaterThanOrEqualTo(1);
+        _progressState.LastSliceUploadedBytes.Should().Be(256);
+        _progressState.LastSliceUploadDurationMs.Should().BeGreaterThan(0);
+        _progressState.SliceMetrics.Should().HaveCount(1);
+        var metric = _progressState.SliceMetrics[0];
+        metric.PartNumber.Should().Be(1);
+        metric.Bytes.Should().Be(256);
+        metric.DurationMs.Should().BeGreaterThan(0);
+        metric.BandwidthKbps.Should().BeGreaterThanOrEqualTo(0);
+
+        _mockLogger.Verify(x => x.Log(
+            It.Is<LogLevel>(l => l == LogLevel.Information),
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Slice") && v.ToString()!.Contains("bytes") && v.ToString()!.Contains("kbps")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.AtLeastOnce);
+    }
+
+    [Test]
+    public async Task UploadAvailableSlicesAsync_OnError_ShouldAccumulateExceptions()
+    {
+        var slice = new FileUploaderSlice(1, new MemoryStream(new byte[128]));
+        _mockFileTransferApiClient.Setup(x => x.GetUploadFileStorageLocation(It.IsAny<TransferParameters>()))
+            .ThrowsAsync(new Exception("net error"));
+
+        await _availableSlices.Writer.WriteAsync(slice);
+        _availableSlices.Writer.Complete();
+
+        await _fileUploadWorker.UploadAvailableSlicesAsync(_availableSlices, _progressState);
+
+        _progressState.LastException.Should().NotBeNull();
+        _progressState.Exceptions.Should().NotBeNull();
+        _progressState.Exceptions.Count.Should().Be(1);
+    }
+}
+
+

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadWorkerMetricsTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadWorkerMetricsTests.cs
@@ -19,18 +19,18 @@ namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
 [TestFixture]
 public class FileUploadWorkerMetricsTests
 {
-    private Mock<IPolicyFactory> _mockPolicyFactory;
-    private Mock<IFileTransferApiClient> _mockFileTransferApiClient;
-    private Mock<ILogger<FileUploadWorker>> _mockLogger;
-    private Mock<IIndex<StorageProvider, IUploadStrategy>> _mockStrategies;
-    private AsyncRetryPolicy<UploadFileResponse> _policy;
-    private SharedFileDefinition _sharedFileDefinition;
-    private ManualResetEvent _exceptionOccurred;
-    private ManualResetEvent _uploadingIsFinished;
-    private FileUploadWorker _fileUploadWorker;
-    private Channel<FileUploaderSlice> _availableSlices;
-    private UploadProgressState _progressState;
-    private SemaphoreSlim _semaphoreSlim;
+    private Mock<IPolicyFactory> _mockPolicyFactory = null!;
+    private Mock<IFileTransferApiClient> _mockFileTransferApiClient = null!;
+    private Mock<ILogger<FileUploadWorker>> _mockLogger = null!;
+    private Mock<IIndex<StorageProvider, IUploadStrategy>> _mockStrategies = null!;
+    private AsyncRetryPolicy<UploadFileResponse> _policy = null!;
+    private SharedFileDefinition _sharedFileDefinition = null!;
+    private ManualResetEvent _exceptionOccurred = null!;
+    private ManualResetEvent _uploadingIsFinished = null!;
+    private FileUploadWorker _fileUploadWorker = null!;
+    private Channel<FileUploaderSlice> _availableSlices = null!;
+    private UploadProgressState _progressState = null!;
+    private SemaphoreSlim _semaphoreSlim = null!;
 
     [SetUp]
     public void SetUp()
@@ -70,60 +70,19 @@ public class FileUploadWorkerMetricsTests
 
         _mockPolicyFactory.Setup(x => x.BuildFileUploadPolicy()).Returns(_policy);
     }
-
+    
     [TearDown]
     public void TearDown()
     {
-        _exceptionOccurred?.Dispose();
-        _uploadingIsFinished?.Dispose();
-        _semaphoreSlim?.Dispose();
-    }
-
-    [Test]
-    public async Task UploadAvailableSlicesAsync_ShouldTrackBytesAndConcurrency()
-    {
-        var slice = new FileUploaderSlice(1, new MemoryStream(new byte[256]));
-        var storageProvider = StorageProvider.AzureBlobStorage;
-        var mockUploadStrategy = new Mock<IUploadStrategy>();
-        var mockUploadLocation = new FileStorageLocation("https://test.example.com/upload", storageProvider);
-
-        mockUploadStrategy.Setup(x => x.UploadAsync(It.IsAny<FileUploaderSlice>(), It.IsAny<FileStorageLocation>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(UploadFileResponse.Success(200));
-
-        _mockStrategies.Setup(x => x[storageProvider]).Returns(mockUploadStrategy.Object);
-        _mockFileTransferApiClient.Setup(x => x.GetUploadFileStorageLocation(It.IsAny<TransferParameters>()))
-            .ReturnsAsync(mockUploadLocation);
-        _mockFileTransferApiClient.Setup(x => x.AssertFilePartIsUploaded(It.IsAny<TransferParameters>()))
-            .Returns(Task.CompletedTask);
-
-        await _availableSlices.Writer.WriteAsync(slice);
-        _availableSlices.Writer.Complete();
-
-        await _fileUploadWorker.UploadAvailableSlicesAsync(_availableSlices, _progressState);
-
-        _progressState.TotalUploadedSlices.Should().Be(1);
-        _progressState.TotalUploadedBytes.Should().Be(256);
-        _progressState.MaxConcurrentUploads.Should().BeGreaterThanOrEqualTo(1);
-        _progressState.LastSliceUploadedBytes.Should().Be(256);
-        _progressState.LastSliceUploadDurationMs.Should().BeGreaterThan(0);
-        _progressState.SliceMetrics.Should().HaveCount(1);
-        var metric = _progressState.SliceMetrics[0];
-        metric.PartNumber.Should().Be(1);
-        metric.Bytes.Should().Be(256);
-        metric.DurationMs.Should().BeGreaterThan(0);
-        metric.BandwidthKbps.Should().BeGreaterThanOrEqualTo(0);
-
-        _mockLogger.Verify(x => x.Log(
-            It.Is<LogLevel>(l => l == LogLevel.Information),
-            It.IsAny<EventId>(),
-            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Slice") && v.ToString()!.Contains("bytes") && v.ToString()!.Contains("kbps")),
-            It.IsAny<Exception>(),
-            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.AtLeastOnce);
+        _exceptionOccurred.Dispose();
+        _uploadingIsFinished.Dispose();
+        _semaphoreSlim.Dispose();
     }
 
     [Test]
     public async Task UploadAvailableSlicesAsync_OnError_ShouldAccumulateExceptions()
     {
+        // Arrange
         var slice = new FileUploaderSlice(1, new MemoryStream(new byte[128]));
         _mockFileTransferApiClient.Setup(x => x.GetUploadFileStorageLocation(It.IsAny<TransferParameters>()))
             .ThrowsAsync(new Exception("net error"));
@@ -131,9 +90,10 @@ public class FileUploadWorkerMetricsTests
         await _availableSlices.Writer.WriteAsync(slice);
         _availableSlices.Writer.Complete();
 
+        // Act
         await _fileUploadWorker.UploadAvailableSlicesAsync(_availableSlices, _progressState);
 
-        _progressState.LastException.Should().NotBeNull();
+        // Assert
         _progressState.Exceptions.Should().NotBeNull();
         _progressState.Exceptions.Count.Should().Be(1);
     }

--- a/tests/ByteSync.ServerCommon.Tests/Repositories/InventoryRepositoryTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Repositories/InventoryRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿using ByteSync.ServerCommon.Business.Sessions;
-using ByteSync.ServerCommon.Entities;
+﻿using ByteSync.ServerCommon.Entities;
 using ByteSync.ServerCommon.Entities.Inventories;
 using ByteSync.ServerCommon.Factories;
 using ByteSync.ServerCommon.Repositories;

--- a/tests/ByteSync.ServerCommon.Tests/Repositories/TrackingActionRepositoryTests.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Repositories/TrackingActionRepositoryTests.cs
@@ -1,8 +1,6 @@
 ﻿using ByteSync.Common.Business.Actions;
-using ByteSync.ServerCommon.Business.Repositories;
 using ByteSync.ServerCommon.Entities;
 using ByteSync.ServerCommon.Factories;
-using ByteSync.ServerCommon.Interfaces.Factories;
 using ByteSync.ServerCommon.Interfaces.Repositories;
 using ByteSync.ServerCommon.Interfaces.Services;
 using ByteSync.ServerCommon.Repositories;


### PR DESCRIPTION
### Summary
- **Metrics**: Refined per-slice upload metrics and captured worker `TaskId` to observe parallelism.
- **Error handling**: Replaced single `LastException` with aggregated `Exceptions` list.
- **Tests**: Added integration tests validating slicing, parallelism, and total uploaded length; updated unit tests accordingly.
- **Cleanup**: Minor code cleanups and API alignment.

### Why
- Bandwidth computation per slice was noisy and unnecessary; external computation can derive rates from bytes and elapsed time.
- Aggregating errors provides richer diagnostics and avoids losing earlier failures.
- Integration coverage ensures slicing behavior and concurrency limits are correct across scenarios.

### What changed
- `SliceUploadMetric`:
  - Added: `TaskId`.
  - Renamed: `DurationMs` → `ElapsedtimeMs`.
  - Removed: `BandwidthKbps`.
- `UploadProgressState`:
  - Removed: `LastException`.
  - Use `Exceptions` list for error aggregation.
- `FileSlicer` / `FileUploadWorker`:
  - Stop setting `LastException`; append to `Exceptions` instead.
  - Record `TaskId`, `PartNumber`, `Bytes`, `ElapsedtimeMs` for each slice.
- `FileUploadProcessor`:
  - After upload, throw with the last aggregated exception if any exist.
  - Use null-safe count checks.
- Tests:
  - New integration suite `Upload_SliceAndParallelism_Tests` with a stub `IUploadStrategy` and `IFileTransferApiClient` to:
    - Validate one-slice uploads, multi-slice uploads, and two-file uploads.
    - Assert total slice counts, distinct worker `TaskId` counts, and final uploaded length.
  - Updated `UploadProgressState` unit tests to use `Exceptions` (including null, different types, inner exceptions, messages).
  - Minor cleanup in `FileUploaderSliceTests` (remove unused using).

### Breaking changes
- Public model changes:
  - `SliceUploadMetric`: property rename/removal and new property added.
  - `UploadProgressState`: `LastException` removed in favor of `Exceptions`.
- Impact expected to be internal to the client; downstream consumers must update references accordingly.