### PR TITLE
[feature] Improve upload management adaptive controller

### DIFF
--- a/src/ByteSync.Client/Factories/FileUploadProcessorFactory.cs
+++ b/src/ByteSync.Client/Factories/FileUploadProcessorFactory.cs
@@ -50,6 +50,8 @@ public class FileUploadProcessorFactory : IFileUploadProcessorFactory
         var sessionService = _context.Resolve<ISessionService>();
         var filePartUploadAsserter = new FilePartUploadAsserter(fileTransferApiClient, sessionService);
         
+        var adaptiveUploadController = _context.Resolve<IAdaptiveUploadController>();
+
         var fileUploadProcessor = _context.Resolve<IFileUploadProcessor>(
             new TypedParameter(typeof(ISlicerEncrypter), slicerEncrypter),
             new TypedParameter(typeof(IFileUploadCoordinator), fileUploadCoordinator),
@@ -57,7 +59,8 @@ public class FileUploadProcessorFactory : IFileUploadProcessorFactory
             new TypedParameter(typeof(IFileUploadWorker), fileUploadWorker),
             new TypedParameter(typeof(IFilePartUploadAsserter), filePartUploadAsserter),
             new TypedParameter(typeof(string), localFileToUpload),
-            new TypedParameter(typeof(SemaphoreSlim), semaphoreSlim)
+            new TypedParameter(typeof(SemaphoreSlim), semaphoreSlim),
+            new TypedParameter(typeof(IAdaptiveUploadController), adaptiveUploadController)
         );
         
         return fileUploadProcessor;

--- a/src/ByteSync.Client/Factories/FileUploaderFactory.cs
+++ b/src/ByteSync.Client/Factories/FileUploaderFactory.cs
@@ -51,6 +51,7 @@ public class FileUploaderFactory : IFileUploaderFactory
         
         var sessionService = _context.Resolve<ISessionService>();
         var filePartUploadAsserter = new FilePartUploadAsserter(fileTransferApiClient, sessionService);
+        var adaptiveUploadController = _context.Resolve<IAdaptiveUploadController>();
         
         var fileUploader = _context.Resolve<IFileUploader>(
             new TypedParameter(typeof(string), fullName),
@@ -61,7 +62,8 @@ public class FileUploaderFactory : IFileUploaderFactory
             new TypedParameter(typeof(IFileUploadWorker), fileUploadWorker),
             new TypedParameter(typeof(IFilePartUploadAsserter), filePartUploadAsserter),
             new TypedParameter(typeof(ISlicerEncrypter), slicerEncrypter),
-            new TypedParameter(typeof(SemaphoreSlim), semaphoreSlim)
+            new TypedParameter(typeof(SemaphoreSlim), semaphoreSlim),
+            new TypedParameter(typeof(IAdaptiveUploadController), adaptiveUploadController)
         );
         
         return fileUploader;

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IAdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IAdaptiveUploadController.cs
@@ -1,0 +1,15 @@
+namespace ByteSync.Interfaces.Controls.Communications;
+
+public interface IAdaptiveUploadController
+{
+	int CurrentChunkSizeBytes { get; }
+	int CurrentParallelism { get; }
+
+	// Returns the chunk size to use for the next slice
+	int GetNextChunkSizeBytes();
+
+	// Record the result of an upload attempt for a slice
+	void RecordUploadResult(TimeSpan elapsed, bool isSuccess, int partNumber, int? statusCode = null, Exception? exception = null);
+}
+
+

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IFileSlicer.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IFileSlicer.cs
@@ -7,5 +7,8 @@ public interface IFileSlicer
 {
     Task SliceAndEncryptAsync(SharedFileDefinition sharedFileDefinition, UploadProgressState progressState, 
         int? maxSliceLength = null);
+
+	Task SliceAndEncryptAdaptiveAsync(SharedFileDefinition sharedFileDefinition, UploadProgressState progressState,
+	    IAdaptiveUploadController adaptiveUploadController);
 } 
 

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IFileUploadWorker.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IFileUploadWorker.cs
@@ -8,4 +8,7 @@ public interface IFileUploadWorker
     Task UploadAvailableSlicesAsync(Channel<FileUploaderSlice> availableSlices, UploadProgressState progressState);
     
     void StartUploadWorkers(Channel<FileUploaderSlice> availableSlices, int workerCount, UploadProgressState progressState);
+
+	Task UploadAvailableSlicesAdaptiveAsync(Channel<FileUploaderSlice> availableSlices, UploadProgressState progressState,
+	    IAdaptiveUploadController adaptiveUploadController);
 } 

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
@@ -1,0 +1,174 @@
+using ByteSync.Interfaces.Controls.Communications;
+using Microsoft.Extensions.Logging;
+
+namespace ByteSync.Services.Communications.Transfers.Uploading;
+
+public class AdaptiveUploadController : IAdaptiveUploadController
+{
+	// Initial configuration
+	private const int INITIAL_CHUNK_SIZE_BYTES = 500 * 1024; // 500 KB
+	private const int MIN_PARALLELISM = 2;
+	private const int MAX_PARALLELISM = 4;
+
+	// Thresholds
+	private static readonly TimeSpan UpscaleThreshold = TimeSpan.FromSeconds(25);
+	private static readonly TimeSpan DownscaleThreshold = TimeSpan.FromSeconds(30);
+
+	// Chunk size thresholds for parallelism increases
+	private const int FOUR_MB = 4 * 1024 * 1024;
+	private const int EIGHT_MB = 8 * 1024 * 1024;
+
+	// State
+	private int _currentChunkSizeBytes;
+	private int _currentParallelism;
+	private readonly Queue<TimeSpan> _recentDurations;
+	private readonly Queue<int> _recentPartNumbers;
+	private readonly Queue<bool> _recentSuccesses;
+	private int _successesInWindow;
+	private int _windowSize;
+	private readonly ILogger<AdaptiveUploadController> _logger;
+
+	public AdaptiveUploadController(ILogger<AdaptiveUploadController> logger)
+	{
+		_logger = logger;
+		_currentChunkSizeBytes = INITIAL_CHUNK_SIZE_BYTES;
+		_currentParallelism = MIN_PARALLELISM;
+		_recentDurations = new Queue<TimeSpan>();
+		_recentPartNumbers = new Queue<int>();
+		_recentSuccesses = new Queue<bool>();
+		_windowSize = _currentParallelism;
+	}
+
+	public int CurrentChunkSizeBytes => _currentChunkSizeBytes;
+	public int CurrentParallelism => _currentParallelism;
+
+	public int GetNextChunkSizeBytes()
+	{
+		return _currentChunkSizeBytes;
+	}
+
+	public void RecordUploadResult(TimeSpan elapsed, bool isSuccess, int partNumber, int? statusCode = null, Exception? exception = null)
+	{
+		// Track window of last N uploads where N == current parallelism
+		_recentDurations.Enqueue(elapsed);
+		_recentPartNumbers.Enqueue(partNumber);
+		_recentSuccesses.Enqueue(isSuccess);
+		if (isSuccess) { _successesInWindow += 1; }
+		while (_recentDurations.Count > _windowSize)
+		{
+			_recentDurations.Dequeue();
+			if (_recentPartNumbers.Count > 0)
+			{
+				_recentPartNumbers.Dequeue();
+			}
+			if (_recentSuccesses.Count > 0)
+			{
+				var removedSuccess = _recentSuccesses.Dequeue();
+				if (removedSuccess && _successesInWindow > 0)
+				{
+					_successesInWindow -= 1;
+				}
+			}
+		}
+
+		// If error indicates bandwidth problems, reset chunk size
+		if (!isSuccess && statusCode != null)
+		{
+			if (statusCode == 429 || statusCode == 503 || statusCode == 507)
+			{
+				_logger.LogWarning("Adaptive: bandwidth error status {Status}. Resetting chunk size to {InitialKb} KB (was {PrevKb} KB)", statusCode, INITIAL_CHUNK_SIZE_BYTES / 1024, _currentChunkSizeBytes / 1024);
+				_currentChunkSizeBytes = INITIAL_CHUNK_SIZE_BYTES;
+				return;
+			}
+		}
+
+		if (_recentDurations.Count < _windowSize)
+		{
+			return; // not enough data yet
+		}
+
+		var maxElapsed = TimeSpan.Zero;
+		foreach (var d in _recentDurations)
+		{
+			if (d > maxElapsed) maxElapsed = d;
+		}
+
+		_logger.LogDebug(
+			"Adaptive: maxElapsedMs={MaxElapsedMs}, parallelism={Parallelism}, chunkKB={ChunkKb}",
+			maxElapsed.TotalMilliseconds, _currentParallelism, _currentChunkSizeBytes / 1024);
+
+		// Downscale path first
+		if (maxElapsed > DownscaleThreshold)
+		{
+			// Adjust chunk size first (incremental), then parallelism in the same evaluation
+			_currentChunkSizeBytes = (int)Math.Max(64 * 1024, _currentChunkSizeBytes * 0.75);
+			_logger.LogInformation(
+				"Adaptive: Downscale. maxElapsedMs={MaxElapsedMs} > {ThresholdMs}. New chunkKB={ChunkKb}.", 
+				maxElapsed.TotalMilliseconds, DownscaleThreshold.TotalMilliseconds, _currentChunkSizeBytes / 1024);
+			if (_currentParallelism > MIN_PARALLELISM)
+			{
+				_logger.LogInformation(
+					"Adaptive: Downscale. Reducing parallelism {Prev} -> {Next}. Resetting window.",
+					_currentParallelism, _currentParallelism - 1);
+				_currentParallelism -= 1;
+				_windowSize = _currentParallelism;
+			}
+			// Logging before resetting window done above; now reset
+			ResetWindow();
+			return;
+		}
+
+		// Upscale when stable and fast (<= 25s) and all in window were successful
+		if (maxElapsed <= UpscaleThreshold && _successesInWindow >= _windowSize)
+		{
+			// Increase chunk size up to 25% per step, but target towards 25s heuristically
+			// Simple rule: +25%
+			var increased = (int)(_currentChunkSizeBytes * 1.25);
+			_currentChunkSizeBytes = increased;
+			_logger.LogInformation(
+				"Adaptive: Upscale. maxElapsedMs={MaxElapsedMs} <= {ThresholdMs}. New chunkKB={ChunkKb}.", 
+				maxElapsed.TotalMilliseconds, UpscaleThreshold.TotalMilliseconds, _currentChunkSizeBytes / 1024);
+
+			// Increase parallelism at thresholds of chunk size
+			if (_currentChunkSizeBytes >= EIGHT_MB)
+			{
+				var prev = _currentParallelism;
+				_currentParallelism = Math.Max(_currentParallelism, 4);
+				if (_currentParallelism != prev)
+				{
+					_logger.LogInformation("Adaptive: Upscale. Increasing parallelism {Prev} -> {Next} due to chunk>=8MB.", prev, _currentParallelism);
+				}
+			}
+			else if (_currentChunkSizeBytes >= FOUR_MB)
+			{
+				var prev = _currentParallelism;
+				_currentParallelism = Math.Max(_currentParallelism, 3);
+				if (_currentParallelism != prev)
+				{
+					_logger.LogInformation("Adaptive: Upscale. Increasing parallelism {Prev} -> {Next} due to chunk>=4MB.", prev, _currentParallelism);
+				}
+			}
+			_currentParallelism = Math.Min(_currentParallelism, MAX_PARALLELISM);
+			_windowSize = _currentParallelism;
+		}
+	}
+
+	private void ResetWindow()
+	{
+		while (_recentDurations.Count > 0)
+		{
+			_recentDurations.Dequeue();
+		}
+		while (_recentPartNumbers.Count > 0)
+		{
+			_recentPartNumbers.Dequeue();
+		}
+		while (_recentSuccesses.Count > 0)
+		{
+			_recentSuccesses.Dequeue();
+		}
+		_successesInWindow = 0;
+	}
+}
+
+

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
@@ -87,4 +87,65 @@ public class FileSlicer : IFileSlicer
             _exceptionOccurred.Set();
         }
     }
+
+	public async Task SliceAndEncryptAdaptiveAsync(SharedFileDefinition sharedFileDefinition, UploadProgressState progressState,
+	    IAdaptiveUploadController adaptiveUploadController)
+	{
+		try
+		{
+			_slicerEncrypter.MaxSliceLength = adaptiveUploadController.CurrentChunkSizeBytes;
+
+			var canContinue = true;
+			while (canContinue)
+			{
+				if (_exceptionOccurred.WaitOne(0))
+				{
+					return;
+				}
+
+				var nextSize = adaptiveUploadController.GetNextChunkSizeBytes();
+				if (nextSize > 0)
+				{
+					_slicerEncrypter.MaxSliceLength = nextSize;
+				}
+
+				var fileUploaderSlice = await _slicerEncrypter.SliceAndEncrypt();
+
+				if (fileUploaderSlice != null)
+				{
+					await _semaphoreSlim.WaitAsync();
+					try
+					{
+						progressState.TotalCreatedSlices += 1;
+					}
+					finally
+					{
+						_semaphoreSlim.Release();
+					}
+
+					await _availableSlices.Writer.WriteAsync(fileUploaderSlice);
+				}
+				else
+				{
+					_availableSlices.Writer.Complete();
+					canContinue = false;
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "SliceAndEncryptAdaptive");
+
+			await _semaphoreSlim.WaitAsync();
+			try
+			{
+				progressState.Exceptions.Add(ex);
+			}
+			finally
+			{
+				_semaphoreSlim.Release();
+			}
+			_exceptionOccurred.Set();
+		}
+	}
 } 

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
@@ -17,7 +17,7 @@ public class FileUploadCoordinator : IFileUploadCoordinator
     {
         _logger = logger;
         _syncRoot = new object();
-        _availableSlices = Channel.CreateBounded<FileUploaderSlice>(8);
+        _availableSlices = Channel.CreateBounded<FileUploaderSlice>(2);
         _uploadingIsFinished = new ManualResetEvent(false);
         _exceptionOccurred = new ManualResetEvent(false);
     }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
@@ -83,7 +83,11 @@ public class FileUploadWorker : IFileUploadWorker
                             PartNumber = slice.PartNumber
                         };
                         
-                        await _fileTransferApiClient.AssertFilePartIsUploaded(transferParameters);
+                        await policy.ExecuteAsync(async () =>
+                        {
+                            await _fileTransferApiClient.AssertFilePartIsUploaded(transferParameters);
+                            return UploadFileResponse.Success(200);
+                        });
                         await _semaphoreSlim.WaitAsync();
                         try
                         {
@@ -188,6 +192,82 @@ public class FileUploadWorker : IFileUploadWorker
             _semaphoreSlim.Release();
         }
     }
+
+	public async Task UploadAvailableSlicesAdaptiveAsync(Channel<FileUploaderSlice> availableSlices, UploadProgressState progressState,
+	    IAdaptiveUploadController adaptiveUploadController)
+	{
+		while (await availableSlices.Reader.WaitToReadAsync())
+		{
+			if (availableSlices.Reader.TryRead(out var slice))
+			{
+				try
+				{
+					var policy = _policyFactory.BuildFileUploadPolicy();
+					var startedAt = DateTime.UtcNow;
+					var response = await policy.ExecuteAsync(() => DoUpload(slice));
+
+					var elapsed = DateTime.UtcNow - startedAt;
+					adaptiveUploadController.RecordUploadResult(elapsed, response != null && response.IsSuccess, slice.PartNumber, response?.StatusCode);
+
+					if (response != null && response.IsSuccess)
+					{
+						var transferParameters = new TransferParameters
+						{
+							SessionId = _sharedFileDefinition.SessionId,
+							SharedFileDefinition = _sharedFileDefinition,
+							PartNumber = slice.PartNumber
+						};
+
+						await _fileTransferApiClient.AssertFilePartIsUploaded(transferParameters);
+						await _semaphoreSlim.WaitAsync();
+						try
+						{
+							progressState.TotalUploadedSlices += 1;
+						}
+						finally
+						{
+							_semaphoreSlim.Release();
+						}
+					}
+					else
+					{
+						throw new Exception($"UploadAvailableSlice: unable to get upload url. Status: {response?.StatusCode}, Error: {response?.ErrorMessage}");
+					}
+				}
+				catch (Exception ex)
+				{
+					_logger.LogError(ex, "UploadAvailableSlice");
+
+					await _semaphoreSlim.WaitAsync();
+					try
+					{
+						progressState.Exceptions.Add(ex);
+					}
+					finally
+					{
+						_semaphoreSlim.Release();
+					}
+
+					_exceptionOccurred.Set();
+
+					return;
+				}
+			}
+		}
+
+		await _semaphoreSlim.WaitAsync();
+		try
+		{
+			if (progressState.TotalUploadedSlices == progressState.TotalCreatedSlices)
+			{
+				_uploadingIsFinished.Set();
+			}
+		}
+		finally
+		{
+			_semaphoreSlim.Release();
+		}
+	}
 
     private async Task<UploadFileResponse> DoUpload(FileUploaderSlice slice)
     {

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploader.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploader.cs
@@ -24,7 +24,8 @@ public class FileUploader : IFileUploader
         IFilePartUploadAsserter filePartUploadAsserter,
         ISlicerEncrypter slicerEncrypter, 
         ILogger<FileUploader> logger,
-        SemaphoreSlim semaphoreSlim)
+        SemaphoreSlim semaphoreSlim,
+        IAdaptiveUploadController adaptiveUploadController)
     {
         if (localFileToUpload == null && memoryStream == null)
         {
@@ -48,7 +49,8 @@ public class FileUploader : IFileUploader
             fileUploadWorker,
             filePartUploadAsserter,
             localFileToUpload,
-            semaphoreSlim);
+            semaphoreSlim,
+            adaptiveUploadController);
     }
 
     public int? MaxSliceLength { get; set; }

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/Upload_SliceAndParallelism_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/Upload_SliceAndParallelism_Tests.cs
@@ -1,0 +1,245 @@
+using Autofac;
+using ByteSync.Business.Communications.Transfers;
+using ByteSync.Client.IntegrationTests.TestHelpers;
+using ByteSync.Common.Business.Communications.Transfers;
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.DependencyInjection;
+using ByteSync.Interfaces.Controls.Communications;
+using ByteSync.Interfaces.Controls.Communications.Http;
+using ByteSync.Interfaces.Factories;
+using ByteSync.Interfaces.Repositories;
+using ByteSync.Services.Communications.Transfers.Uploading;
+using FluentAssertions;
+
+namespace ByteSync.Client.IntegrationTests.Services.Communications.Transfers;
+
+public class Upload_SliceAndParallelism_Tests
+{
+    private ILifetimeScope _clientScope = null!;
+
+    private class TestUploadStrategy : IUploadStrategy
+    {
+        private static readonly object Sync = new object();
+        public static readonly Dictionary<string, List<(int PartNumber, long Bytes, int TaskId)>> Records = new();
+
+        public Task<UploadFileResponse> UploadAsync(FileUploaderSlice slice, FileStorageLocation storageLocation, CancellationToken cancellationToken)
+        {
+            var taskId = Environment.CurrentManagedThreadId;
+            lock (Sync)
+            {
+                var sharedId = storageLocation.Url; // We will encode SharedFileDefinition.Id in the URL via TestApiClient
+                if (!Records.ContainsKey(sharedId))
+                {
+                    Records[sharedId] = new List<(int, long, int)>();
+                }
+                Records[sharedId].Add((slice.PartNumber, slice.MemoryStream?.Length ?? 0L, taskId));
+            }
+            return Task.FromResult(UploadFileResponse.Success(200));
+        }
+    }
+
+    private class TestFileTransferApiClient : IFileTransferApiClient
+    {
+        public Task<string> GetUploadFileUrl(TransferParameters transferParameters)
+        {
+            // Use SharedFileDefinition.Id as a pseudo URL to key records
+            return Task.FromResult(transferParameters.SharedFileDefinition.Id);
+        }
+
+        public async Task<FileStorageLocation> GetUploadFileStorageLocation(TransferParameters transferParameters)
+        {
+            var url = await GetUploadFileUrl(transferParameters);
+            return new FileStorageLocation(url, StorageProvider.AzureBlobStorage);
+        }
+
+        public Task<string> GetDownloadFileUrl(TransferParameters transferParameters) => Task.FromResult(string.Empty);
+        public Task<FileStorageLocation> GetDownloadFileStorageLocation(TransferParameters transferParameters) => Task.FromResult(new FileStorageLocation(string.Empty, StorageProvider.AzureBlobStorage));
+        public Task AssertFilePartIsUploaded(TransferParameters transferParameters) => Task.CompletedTask;
+        public Task AssertUploadIsFinished(TransferParameters transferParameters) => Task.CompletedTask;
+        public Task AssertFilePartIsDownloaded(TransferParameters transferParameters) => Task.CompletedTask;
+        public Task AssertDownloadIsFinished(TransferParameters transferParameters) => Task.CompletedTask;
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        if (ByteSync.Services.ContainerProvider.Container == null)
+        {
+            ServiceRegistrar.RegisterComponents();
+        }
+
+        _clientScope = ByteSync.Services.ContainerProvider.Container!.BeginLifetimeScope(b =>
+        {
+            // Override HTTP client with local test client and upload strategy
+            b.RegisterType<TestFileTransferApiClient>().As<IFileTransferApiClient>().SingleInstance();
+            b.RegisterType<TestUploadStrategy>().Keyed<IUploadStrategy>(StorageProvider.AzureBlobStorage).SingleInstance();
+        });
+
+        // Set AES key for encryption used by SlicerEncrypter
+        using var scope = _clientScope.BeginLifetimeScope();
+        var cloudSessionConnectionRepository = scope.Resolve<ICloudSessionConnectionRepository>();
+        cloudSessionConnectionRepository.SetAesEncryptionKey(AesGenerator.GenerateKey());
+
+        // Clear previous records
+        lock (TestUploadStrategy.Records)
+        {
+            TestUploadStrategy.Records.Clear();
+        }
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _clientScope.Dispose();
+    }
+
+    private static SharedFileDefinition BuildShared(string? id = null)
+    {
+        return new SharedFileDefinition
+        {
+            Id = id ?? Guid.NewGuid().ToString("N"),
+            SessionId = "itests-" + Guid.NewGuid().ToString("N"),
+            ClientInstanceId = Guid.NewGuid().ToString("N"),
+            SharedFileType = SharedFileTypes.FullSynchronization,
+            IV = AesGenerator.GenerateIV()
+        };
+    }
+
+    [Test]
+    public async Task Upload_OneSmallFile_FixedSliceLen_FixedParallel_ShouldHaveOneTaskAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared = BuildShared("small1");
+
+        var tempFile = Path.GetTempFileName();
+        var inputContent = new string('a', 512); // smaller than slice
+        await File.WriteAllTextAsync(tempFile, inputContent);
+
+        var uploader = uploaderFactory.Build(tempFile, shared) as FileUploader;
+        uploader!.MaxSliceLength = 1024; // fixed slice length
+
+        await uploader.Upload();
+
+        TestUploadStrategy.Records.ContainsKey(shared.Id).Should().BeTrue();
+        var recs = TestUploadStrategy.Records[shared.Id];
+        recs.Count.Should().Be(1); // only one slice/task
+        recs.Select(r => r.TaskId).Distinct().Count().Should().Be(1); // one worker involved
+        shared.UploadedFileLength.Should().Be(inputContent.Length); // full length transferred
+    }
+
+    [Test]
+    public async Task Upload_OneBigFile_ThreeSlices_Parallel1_ShouldHaveThreeTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared = BuildShared("big1");
+
+        var tempFile = Path.GetTempFileName();
+        var sliceLength = 500 * 1024; // 500KB;
+        var inputContent = new string('b', sliceLength * 3 + 1); // > 3x slice length => 4 slices
+        await File.WriteAllTextAsync(tempFile, inputContent);
+
+        var uploader = uploaderFactory.Build(tempFile, shared) as FileUploader;
+        uploader!.MaxSliceLength = sliceLength; // fixed slice length
+
+        await uploader.Upload();
+
+        var recs = TestUploadStrategy.Records[shared.Id];
+        recs.Count.Should().Be(4);
+        recs.Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        shared.UploadedFileLength.Should().Be(inputContent.Length);
+    }
+
+    [Test]
+    public async Task Upload_OneBigFile_ThreeSlices_Parallel3_ShouldHaveThreeTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared = BuildShared("big3");
+
+        var tempFile = Path.GetTempFileName();
+        var sliceLength = 500 * 1024; // 500KB;;
+        var inputContent = new string('c', sliceLength * 3 + 5); // > 3x slice length => 4 slices
+        await File.WriteAllTextAsync(tempFile, inputContent);
+
+        var uploader = uploaderFactory.Build(tempFile, shared) as FileUploader;
+        uploader!.MaxSliceLength = sliceLength;
+
+        await uploader.Upload();
+
+        var recs = TestUploadStrategy.Records[shared.Id];
+        recs.Count.Should().Be(4);
+        recs.Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        shared.UploadedFileLength.Should().Be(inputContent.Length);
+    }
+
+    [Test]
+    public async Task Upload_TwoSmallFiles_FixedSliceLen_FixedParallel_ShouldHaveTwoTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared1 = BuildShared("s1");
+        var shared2 = BuildShared("s2");
+
+        var tempFile1 = Path.GetTempFileName();
+        var tempFile2 = Path.GetTempFileName();
+        var c1 = new string('x', 400);
+        var c2 = new string('y', 700);
+        await File.WriteAllTextAsync(tempFile1, c1);
+        await File.WriteAllTextAsync(tempFile2, c2);
+
+        var uploader1 = uploaderFactory.Build(tempFile1, shared1) as FileUploader;
+        var uploader2 = uploaderFactory.Build(tempFile2, shared2) as FileUploader;
+        uploader1!.MaxSliceLength = 1024;
+        uploader2!.MaxSliceLength = 1024;
+
+        await uploader1.Upload();
+        await uploader2.Upload();
+
+        TestUploadStrategy.Records[shared1.Id].Count.Should().Be(1);
+        TestUploadStrategy.Records[shared2.Id].Count.Should().Be(1);
+        shared1.UploadedFileLength.Should().Be(c1.Length);
+        shared2.UploadedFileLength.Should().Be(c2.Length);
+    }
+
+    [Test]
+    public async Task Upload_TwoBigFiles_ThreeSlicesEach_Parallel3_ShouldHaveThreeTasksAndFullLength()
+    {
+        using var scope = _clientScope;
+        var uploaderFactory = scope.Resolve<IFileUploaderFactory>();
+
+        var shared1 = BuildShared("b1");
+        var shared2 = BuildShared("b2");
+
+        var sliceLength = 500 * 1024; // 500KB;;
+        var c1 = new string('m', sliceLength * 3 + 3); // > 3x slice length => 4 slices
+        var c2 = new string('n', sliceLength * 3 + 7); // > 3x slice length => 4 slices
+
+        var tempFile1 = Path.GetTempFileName();
+        var tempFile2 = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tempFile1, c1);
+        await File.WriteAllTextAsync(tempFile2, c2);
+
+        var uploader1 = uploaderFactory.Build(tempFile1, shared1) as FileUploader;
+        var uploader2 = uploaderFactory.Build(tempFile2, shared2) as FileUploader;
+        uploader1!.MaxSliceLength = sliceLength;
+        uploader2!.MaxSliceLength = sliceLength;
+
+        await uploader1.Upload();
+        await uploader2.Upload();
+
+        TestUploadStrategy.Records[shared1.Id].Count.Should().Be(4);
+        TestUploadStrategy.Records[shared2.Id].Count.Should().Be(4);
+        TestUploadStrategy.Records[shared1.Id].Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        TestUploadStrategy.Records[shared2.Id].Select(r => r.TaskId).Distinct().Count().Should().BeLessThanOrEqualTo(3).And.BeGreaterThanOrEqualTo(1);
+        shared1.UploadedFileLength.Should().Be(c1.Length);
+        shared2.UploadedFileLength.Should().Be(c2.Length);
+    }
+}
+
+

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
@@ -1,0 +1,124 @@
+using ByteSync.Services.Communications.Transfers.Uploading;
+using Microsoft.Extensions.Logging.Abstractions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
+
+[TestFixture]
+public class AdaptiveUploadControllerTests
+{
+    private AdaptiveUploadController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _controller = new AdaptiveUploadController(NullLogger<AdaptiveUploadController>.Instance);
+    }
+
+    [Test]
+    public void Initializes_WithDefaults()
+    {
+        // Arrange
+        // (controller is created in SetUp)
+
+        // Act
+        // (no action)
+
+        // Assert
+        _controller.CurrentParallelism.Should().Be(2);
+        _controller.CurrentChunkSizeBytes.Should().Be(500 * 1024);
+    }
+
+    [Test]
+    public void Upscales_AfterFastWindow()
+    {
+        // Arrange
+        var beforeSize = _controller.CurrentChunkSizeBytes;
+
+        // Act - Two fast successful uploads fill the initial window
+        FeedFastWindow(_controller);
+
+        // Assert
+        _controller.CurrentChunkSizeBytes.Should().BeGreaterThan(500 * 1024);
+        _controller.CurrentChunkSizeBytes.Should().BeGreaterThan(beforeSize);
+        _controller.CurrentParallelism.Should().Be(2);
+    }
+
+    [Test]
+    public void IncreasesParallelism_AtFourMbAndEightMb()
+    {
+        // Arrange
+        // (controller at default)
+
+        // Act - Repeatedly feed fast windows until chunk size crosses 4MB
+        var safety = 100;
+        while (_controller.CurrentChunkSizeBytes < 4 * 1024 * 1024 && safety-- > 0)
+        {
+            FeedFastWindow(_controller);
+        }
+        
+        // Assert - at 4MB threshold
+        _controller.CurrentChunkSizeBytes.Should().BeGreaterThanOrEqualTo(4 * 1024 * 1024);
+        _controller.CurrentParallelism.Should().BeGreaterThanOrEqualTo(3);
+        
+        // Act - Continue until 8MB threshold
+        safety = 100;
+        while (_controller.CurrentChunkSizeBytes < 8 * 1024 * 1024 && safety-- > 0)
+        {
+            FeedFastWindow(_controller);
+        }
+        
+        // Assert - at 8MB threshold
+        _controller.CurrentChunkSizeBytes.Should().BeGreaterThanOrEqualTo(8 * 1024 * 1024);
+        _controller.CurrentParallelism.Should().BeGreaterThanOrEqualTo(4);
+    }
+
+    [Test]
+    public void Downscale_ReducesChunkSize_WhenAtMinParallelism()
+    {
+        // Arrange
+        _controller.CurrentParallelism.Should().Be(2);
+        var before = _controller.CurrentChunkSizeBytes;
+        
+        // Act - Slow window triggers downscale
+        FeedWindow(_controller, TimeSpan.FromSeconds(31), successes: true);
+        
+        // Assert - chunk size reduced but not below 64KB
+        _controller.CurrentParallelism.Should().Be(2);
+        _controller.CurrentChunkSizeBytes.Should().BeLessThan(before);
+        _controller.CurrentChunkSizeBytes.Should().BeGreaterThanOrEqualTo(64 * 1024);
+    }
+
+    [Test]
+    public void BandwidthErrors_ResetChunkSize()
+    {
+        // Arrange - Inflate chunk somewhat first
+        FeedFastWindow(_controller);
+        _controller.CurrentChunkSizeBytes.Should().BeGreaterThan(500 * 1024);
+        var parallelismBefore = _controller.CurrentParallelism;
+        
+        // Act - Record bandwidth-related failure (e.g., 429)
+        _controller.RecordUploadResult(TimeSpan.FromSeconds(1), isSuccess: false, partNumber: 1, statusCode: 429);
+        
+        // Assert
+        _controller.CurrentChunkSizeBytes.Should().Be(500 * 1024);
+        _controller.CurrentParallelism.Should().Be(parallelismBefore);
+    }
+
+    private static void FeedFastWindow(AdaptiveUploadController controller)
+    {
+        FeedWindow(controller, TimeSpan.FromSeconds(10), successes: true);
+    }
+
+    private static void FeedWindow(AdaptiveUploadController controller, TimeSpan elapsed, bool successes)
+    {
+        var p = controller.CurrentParallelism;
+        for (var i = 0; i < p; i++)
+        {
+            controller.RecordUploadResult(elapsed, isSuccess: successes, partNumber: i + 1);
+        }
+    }
+}
+
+


### PR DESCRIPTION
#### Summary
Wire `IAdaptiveUploadController` into client-side factories so the adaptive upload controller is constructed and passed down into the upload pipeline.

#### Changes
- Add `IAdaptiveUploadController` resolution and injection in:
  - `src/ByteSync.Client/Factories/FileUploadProcessorFactory.cs`
  - `src/ByteSync.Client/Factories/FileUploaderFactory.cs`

These edits ensure the adaptive controller instance is available to `IFileUploadProcessor` and `IFileUploader` via DI, enabling adaptive chunk sizing/parallelism at runtime.

#### Rationale
Prepares the client upload flow to leverage adaptive bandwidth control by providing the controller at composition time. This isolates policy/heuristics from factories and keeps consumers DI-friendly.

#### Technical Notes
- Both factories resolve `IAdaptiveUploadController` from the existing DI context and pass it as a typed parameter.
- No public API changes in factories; the additional constructor parameter is resolved internally.

#### Backward Compatibility
- Safe: DI resolution only. No behavior change unless the downstream constructors require the new dependency (they do in the corresponding feature branch).
- No config/migration required.

#### Risks
- Misconfigured DI could surface as runtime resolution errors if `IAdaptiveUploadController` is not registered.
- Ensure `IAdaptiveUploadController` and its implementation are registered in the client module(s).

#### Testing
Manual smoke test suggestions:
- Launch a client build that includes the adaptive upload feature.
- Start an upload and confirm no DI resolution errors occur.
- Validate logs to ensure the controller is instantiated once per upload pipeline and methods are invoked during upload.

#### Checklist
- [x] Inject controller in `FileUploadProcessorFactory`
- [x] Inject controller in `FileUploaderFactory`
- [x] No public API changes in factory interfaces
- [x] Build and tests pass locally (please run commands above)