### PR TITLE
feat: improve upload management: FIFO slicing + session-aware adaptiv…

### DIFF
--- a/.github/workflows/trigger-PR-pipeline.yml
+++ b/.github/workflows/trigger-PR-pipeline.yml
@@ -48,7 +48,7 @@ jobs:
           /k:"POW-Software_ByteSync"
           /o:"pow-software"
           /d:sonar.host.url="https://sonarcloud.io"
-          /d:sonar.login="$SONAR_TOKEN"
+          /d:sonar.token="$SONAR_TOKEN"
           /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
           /d:sonar.cs.vstest.reportsPaths="**/*.trx"
 
@@ -61,7 +61,7 @@ jobs:
       - name: SonarCloud End (publish)
         run: >
           dotnet sonarscanner end
-          /d:sonar.login="$SONAR_TOKEN"
+          /d:sonar.token="$SONAR_TOKEN"
 
   discover-tests:
     runs-on: ubuntu-latest

--- a/src/ByteSync.Client/DependencyInjection/Modules/SingletonsModule.cs
+++ b/src/ByteSync.Client/DependencyInjection/Modules/SingletonsModule.cs
@@ -6,6 +6,8 @@ using ByteSync.Services.Communications;
 using ByteSync.Services.Communications.SignalR;
 using ByteSync.Services.Communications.Transfers.Downloading;
 using ByteSync.Services.Inventories;
+using ByteSync.Services.Communications.Transfers.Uploading;
+using ByteSync.Interfaces.Controls.Communications;
 using ByteSync.Services.Navigations;
 using ByteSync.Services.Sessions.Connecting;
 using ByteSync.Services.Synchronizations;
@@ -34,5 +36,8 @@ public class SingletonsModule : Module
         builder.RegisterType<SynchronizationStarter>().SingleInstance().AsImplementedInterfaces();
         builder.RegisterType<SynchronizationActionServerInformer>().SingleInstance().AsImplementedInterfaces();
         builder.RegisterType<DownloadManager>().SingleInstance().AsImplementedInterfaces();
+
+        builder.RegisterType<AdaptiveUploadController>().SingleInstance().As<IAdaptiveUploadController>();
+        builder.RegisterType<UploadSlicingManager>().SingleInstance().As<IUploadSlicingManager>();
     }
 }

--- a/src/ByteSync.Client/Factories/FileUploadProcessorFactory.cs
+++ b/src/ByteSync.Client/Factories/FileUploadProcessorFactory.cs
@@ -32,10 +32,8 @@ public class FileUploadProcessorFactory : IFileUploadProcessorFactory
         var fileUploadCoordinator = new FileUploadCoordinator(_context.Resolve<ILogger<FileUploadCoordinator>>());
         var semaphoreSlim = new SemaphoreSlim(1, 1);
         
-        // Create file slicer
+        // Resolve adaptive upload controller
         var adaptiveUploadController = _context.Resolve<IAdaptiveUploadController>();
-        var fileSlicer = new FileSlicer(slicerEncrypter, fileUploadCoordinator.AvailableSlices, 
-            semaphoreSlim, fileUploadCoordinator.ExceptionOccurred, _context.Resolve<ILogger<FileSlicer>>(), adaptiveUploadController);
         
         // Create file upload worker
         var policyFactory = _context.Resolve<IPolicyFactory>();
@@ -53,7 +51,6 @@ public class FileUploadProcessorFactory : IFileUploadProcessorFactory
         var fileUploadProcessor = _context.Resolve<IFileUploadProcessor>(
             new TypedParameter(typeof(ISlicerEncrypter), slicerEncrypter),
             new TypedParameter(typeof(IFileUploadCoordinator), fileUploadCoordinator),
-            new TypedParameter(typeof(IFileSlicer), fileSlicer),
             new TypedParameter(typeof(IFileUploadWorker), fileUploadWorker),
             new TypedParameter(typeof(IFilePartUploadAsserter), filePartUploadAsserter),
             new TypedParameter(typeof(string), localFileToUpload),

--- a/src/ByteSync.Client/Factories/FileUploadProcessorFactory.cs
+++ b/src/ByteSync.Client/Factories/FileUploadProcessorFactory.cs
@@ -49,6 +49,7 @@ public class FileUploadProcessorFactory : IFileUploadProcessorFactory
         var sessionService = _context.Resolve<ISessionService>();
         var filePartUploadAsserter = new FilePartUploadAsserter(fileTransferApiClient, sessionService);
         
+        var slicingManager = _context.Resolve<IUploadSlicingManager>();
         var fileUploadProcessor = _context.Resolve<IFileUploadProcessor>(
             new TypedParameter(typeof(ISlicerEncrypter), slicerEncrypter),
             new TypedParameter(typeof(IFileUploadCoordinator), fileUploadCoordinator),
@@ -57,7 +58,8 @@ public class FileUploadProcessorFactory : IFileUploadProcessorFactory
             new TypedParameter(typeof(IFilePartUploadAsserter), filePartUploadAsserter),
             new TypedParameter(typeof(string), localFileToUpload),
             new TypedParameter(typeof(SemaphoreSlim), semaphoreSlim),
-            new TypedParameter(typeof(IAdaptiveUploadController), adaptiveUploadController)
+            new TypedParameter(typeof(IAdaptiveUploadController), adaptiveUploadController),
+            new TypedParameter(typeof(IUploadSlicingManager), slicingManager)
         );
         
         return fileUploadProcessor;

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IFileSlicer.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IFileSlicer.cs
@@ -5,10 +5,6 @@ namespace ByteSync.Interfaces.Controls.Communications;
 
 public interface IFileSlicer
 {
-	// TODO : remove this method and its implementation
-    Task SliceAndEncryptAsync(SharedFileDefinition sharedFileDefinition, UploadProgressState progressState, 
-        int? maxSliceLength = null);
-
 	Task SliceAndEncryptAdaptiveAsync(SharedFileDefinition sharedFileDefinition, UploadProgressState progressState);
 } 
 

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IFileUploadWorker.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IFileUploadWorker.cs
@@ -5,11 +5,5 @@ namespace ByteSync.Interfaces.Controls.Communications;
 
 public interface IFileUploadWorker
 {
-	// TODO: remove this method and its implementation
-    Task UploadAvailableSlicesAsync(Channel<FileUploaderSlice> availableSlices, UploadProgressState progressState);
-    
-    // TODO: remove this method and its implementation
-    void StartUploadWorkers(Channel<FileUploaderSlice> availableSlices, int workerCount, UploadProgressState progressState);
-
 	Task UploadAvailableSlicesAdaptiveAsync(Channel<FileUploaderSlice> availableSlices, UploadProgressState progressState);
 } 

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IUploadSlicingManager.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IUploadSlicingManager.cs
@@ -1,8 +1,20 @@
+using System.Threading;
+using System.Threading.Channels;
+using ByteSync.Business.Communications.Transfers;
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.Interfaces.Controls.Encryptions;
+
 namespace ByteSync.Interfaces.Controls.Communications;
 
 public interface IUploadSlicingManager
 {
-    Task Enqueue(Func<Task> startSlicingAsync);
+    Task<UploadProgressState> Enqueue(
+        SharedFileDefinition sharedFileDefinition,
+        ISlicerEncrypter slicerEncrypter,
+        Channel<FileUploaderSlice> availableSlices,
+        SemaphoreSlim semaphoreSlim,
+        ManualResetEvent exceptionOccurred,
+        IAdaptiveUploadController adaptiveUploadController);
 }
 
 

--- a/src/ByteSync.Client/Interfaces/Controls/Communications/IUploadSlicingManager.cs
+++ b/src/ByteSync.Client/Interfaces/Controls/Communications/IUploadSlicingManager.cs
@@ -1,0 +1,8 @@
+namespace ByteSync.Interfaces.Controls.Communications;
+
+public interface IUploadSlicingManager
+{
+    Task Enqueue(Func<Task> startSlicingAsync);
+}
+
+

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Linq;
+using ByteSync.Business.Sessions;
 using ByteSync.Interfaces.Controls.Communications;
 using ByteSync.Interfaces.Services.Sessions;
 
@@ -36,6 +38,9 @@ public class AdaptiveUploadController : IAdaptiveUploadController
 		_recentSuccesses = new Queue<bool>();
 		ResetState();
 		sessionService.SessionObservable.Subscribe(_ => { ResetState(); });
+		sessionService.SessionStatusObservable
+			.Where(status => status == SessionStatus.Preparation)
+			.Subscribe(_ => { ResetState(); });
 	}
 
 	public int CurrentChunkSizeBytes => _currentChunkSizeBytes;

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
@@ -17,7 +17,7 @@ public class FileUploadCoordinator : IFileUploadCoordinator
     {
         _logger = logger;
         _syncRoot = new object();
-        _availableSlices = Channel.CreateBounded<FileUploaderSlice>(2);
+        _availableSlices = Channel.CreateUnbounded<FileUploaderSlice>();
         _uploadingIsFinished = new ManualResetEvent(false);
         _exceptionOccurred = new ManualResetEvent(false);
     }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadSlicingManager.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadSlicingManager.cs
@@ -1,0 +1,78 @@
+using System.Threading;
+using System.Threading.Channels;
+using ByteSync.Interfaces.Controls.Communications;
+using ByteSync.Interfaces.Services.Sessions;
+
+namespace ByteSync.Services.Communications.Transfers.Uploading;
+
+public class UploadSlicingManager : IUploadSlicingManager
+{
+    private readonly Channel<Func<Task>> _queue;
+    private readonly List<Task> _workers;
+    private readonly ILogger<UploadSlicingManager> _logger;
+    private const int MAX_CONCURRENT_SLICES = 2;
+    private int _generation;
+    private readonly ISessionService _sessionService;
+
+    public UploadSlicingManager(ILogger<UploadSlicingManager> logger, ISessionService sessionService)
+    {
+        _logger = logger;
+        _queue = Channel.CreateUnbounded<Func<Task>>();
+        _workers = new List<Task>();
+        _generation = 0;
+        _sessionService = sessionService;
+        _sessionService.SessionObservable.Subscribe(_ =>
+        {
+            try
+            {
+                Reset();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "UploadSlicingManager reset on session change failed");
+            }
+        });
+        StartWorkers();
+    }
+
+    public Task Enqueue(Func<Task> startSlicingAsync)
+    {
+        var enqueuedGeneration = _generation;
+        return _queue.Writer.WriteAsync(async () =>
+        {
+            if (enqueuedGeneration != _generation)
+            {
+                return;
+            }
+            await startSlicingAsync();
+        }).AsTask();
+    }
+
+    public void Reset()
+    {
+        Interlocked.Increment(ref _generation);
+    }
+
+    private void StartWorkers()
+    {
+        for (var i = 0; i < MAX_CONCURRENT_SLICES; i++)
+        {
+            _workers.Add(Task.Run(async () =>
+            {
+                await foreach (var work in _queue.Reader.ReadAllAsync())
+                {
+                    try
+                    {
+                        await work();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Slicing worker error");
+                    }
+                }
+            }));
+        }
+    }
+}
+
+

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadSlicingManager.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadSlicingManager.cs
@@ -1,6 +1,11 @@
 using System.Threading;
 using System.Threading.Channels;
+using System.Reactive.Linq;
+using ByteSync.Business.Communications.Transfers;
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.Business.Sessions;
 using ByteSync.Interfaces.Controls.Communications;
+using ByteSync.Interfaces.Controls.Encryptions;
 using ByteSync.Interfaces.Services.Sessions;
 
 namespace ByteSync.Services.Communications.Transfers.Uploading;
@@ -9,19 +14,23 @@ public class UploadSlicingManager : IUploadSlicingManager
 {
     private readonly Channel<Func<Task>> _queue;
     private readonly List<Task> _workers;
+    private readonly List<IDisposable> _subscriptions = new();
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly ILogger<UploadSlicingManager> _logger;
+    private readonly ILogger<FileSlicer> _fileSlicerLogger;
     private const int MAX_CONCURRENT_SLICES = 2;
     private int _generation;
     private readonly ISessionService _sessionService;
 
-    public UploadSlicingManager(ILogger<UploadSlicingManager> logger, ISessionService sessionService)
+    public UploadSlicingManager(ILogger<UploadSlicingManager> logger, ILogger<FileSlicer> fileSlicerLogger, ISessionService sessionService)
     {
         _logger = logger;
+        _fileSlicerLogger = fileSlicerLogger;
         _queue = Channel.CreateUnbounded<Func<Task>>();
         _workers = new List<Task>();
         _generation = 0;
         _sessionService = sessionService;
-        _sessionService.SessionObservable.Subscribe(_ =>
+        _subscriptions.Add(_sessionService.SessionObservable.Subscribe(_ =>
         {
             try
             {
@@ -31,21 +40,50 @@ public class UploadSlicingManager : IUploadSlicingManager
             {
                 _logger.LogError(ex, "UploadSlicingManager reset on session change failed");
             }
-        });
+        }));
+        _subscriptions.Add(_sessionService.SessionStatusObservable
+            .Where(status => status == SessionStatus.Preparation)
+            .Subscribe(_ =>
+            {
+                try
+                {
+                    Reset();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "UploadSlicingManager reset on session status change failed");
+                }
+            }));
         StartWorkers();
     }
 
-    public Task Enqueue(Func<Task> startSlicingAsync)
+    public Task<UploadProgressState> Enqueue(
+        SharedFileDefinition sharedFileDefinition,
+        ISlicerEncrypter slicerEncrypter,
+        Channel<FileUploaderSlice> availableSlices,
+        SemaphoreSlim semaphoreSlim,
+        ManualResetEvent exceptionOccurred,
+        IAdaptiveUploadController adaptiveUploadController)
     {
         var enqueuedGeneration = _generation;
+        var progressState = new UploadProgressState();
+        progressState.StartTimeUtc = DateTimeOffset.UtcNow;
+
         return _queue.Writer.WriteAsync(async () =>
         {
             if (enqueuedGeneration != _generation)
             {
                 return;
             }
-            await startSlicingAsync();
-        }).AsTask();
+            var slicer = new FileSlicer(
+                slicerEncrypter,
+                availableSlices,
+                semaphoreSlim,
+                exceptionOccurred,
+                _fileSlicerLogger,
+                adaptiveUploadController);
+            await slicer.SliceAndEncryptAdaptiveAsync(sharedFileDefinition, progressState);
+        }).AsTask().ContinueWith(_ => progressState);
     }
 
     public void Reset()
@@ -59,18 +97,65 @@ public class UploadSlicingManager : IUploadSlicingManager
         {
             _workers.Add(Task.Run(async () =>
             {
-                await foreach (var work in _queue.Reader.ReadAllAsync())
+                try
                 {
-                    try
+                    await foreach (var work in _queue.Reader.ReadAllAsync(_cancellationTokenSource.Token))
                     {
-                        await work();
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Slicing worker error");
+                        try
+                        {
+                            await work();
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Slicing worker error");
+                        }
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                }
             }));
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var subscription in _subscriptions)
+        {
+            try
+            {
+                subscription.Dispose();
+            }
+            catch
+            {
+            }
+        }
+        _subscriptions.Clear();
+
+        try
+        {
+            _cancellationTokenSource.Cancel();
+        }
+        catch
+        {
+        }
+
+        _queue.Writer.TryComplete();
+
+        try
+        {
+            await Task.WhenAll(_workers).ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+        finally
+        {
+            _cancellationTokenSource.Dispose();
         }
     }
 }

--- a/tests/ByteSync.Client.IntegrationTests/TestHelpers/FixedAdaptiveUploadController.cs
+++ b/tests/ByteSync.Client.IntegrationTests/TestHelpers/FixedAdaptiveUploadController.cs
@@ -1,0 +1,27 @@
+using ByteSync.Interfaces.Controls.Communications;
+
+namespace ByteSync.Client.IntegrationTests.TestHelpers;
+
+public class FixedAdaptiveUploadController : IAdaptiveUploadController
+{
+    public int CurrentChunkSizeBytes { get; private set; }
+    public int CurrentParallelism { get; private set; }
+
+    public FixedAdaptiveUploadController(int chunkSizeBytes, int parallelism)
+    {
+        CurrentChunkSizeBytes = chunkSizeBytes;
+        CurrentParallelism = parallelism;
+    }
+
+    public int GetNextChunkSizeBytes()
+    {
+        return CurrentChunkSizeBytes;
+    }
+
+    public void RecordUploadResult(TimeSpan elapsed, bool isSuccess, int partNumber, int? statusCode = null, Exception? exception = null)
+    {
+        // no-op: fixed behavior for tests
+    }
+}
+
+

--- a/tests/ByteSync.Client.IntegrationTests/TestHelpers/TestFileTransferApiClient.cs
+++ b/tests/ByteSync.Client.IntegrationTests/TestHelpers/TestFileTransferApiClient.cs
@@ -1,0 +1,27 @@
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.Interfaces.Controls.Communications.Http;
+
+namespace ByteSync.Client.IntegrationTests.TestHelpers;
+
+public class TestFileTransferApiClient : IFileTransferApiClient
+{
+    public Task<string> GetUploadFileUrl(TransferParameters transferParameters)
+    {
+        return Task.FromResult(transferParameters.SharedFileDefinition.Id);
+    }
+
+    public async Task<FileStorageLocation> GetUploadFileStorageLocation(TransferParameters transferParameters)
+    {
+        var url = await GetUploadFileUrl(transferParameters);
+        return new FileStorageLocation(url, StorageProvider.AzureBlobStorage);
+    }
+
+    public Task<string> GetDownloadFileUrl(TransferParameters transferParameters) => Task.FromResult(string.Empty);
+    public Task<FileStorageLocation> GetDownloadFileStorageLocation(TransferParameters transferParameters) => Task.FromResult(new FileStorageLocation(string.Empty, StorageProvider.AzureBlobStorage));
+    public Task AssertFilePartIsUploaded(TransferParameters transferParameters) => Task.CompletedTask;
+    public Task AssertUploadIsFinished(TransferParameters transferParameters) => Task.CompletedTask;
+    public Task AssertFilePartIsDownloaded(TransferParameters transferParameters) => Task.CompletedTask;
+    public Task AssertDownloadIsFinished(TransferParameters transferParameters) => Task.CompletedTask;
+}
+
+

--- a/tests/ByteSync.Client.IntegrationTests/TestHelpers/TestUploadStrategy.cs
+++ b/tests/ByteSync.Client.IntegrationTests/TestHelpers/TestUploadStrategy.cs
@@ -1,0 +1,67 @@
+using ByteSync.Business.Communications.Transfers;
+using ByteSync.Common.Business.Communications.Transfers;
+using ByteSync.Common.Business.SharedFiles;
+using ByteSync.Interfaces.Controls.Communications;
+
+namespace ByteSync.Client.IntegrationTests.TestHelpers;
+
+public class TestUploadStrategy : IUploadStrategy
+{
+    private static readonly object Sync = new object();
+    public static readonly Dictionary<string, List<(int PartNumber, long Bytes, int TaskId)>> Records = new();
+    private static int _inFlight;
+    private static int _maxInFlight;
+
+    public static void Reset()
+    {
+        lock (Sync)
+        {
+            Records.Clear();
+        }
+        Interlocked.Exchange(ref _inFlight, 0);
+        Interlocked.Exchange(ref _maxInFlight, 0);
+    }
+
+    public static int MaxInFlight => Volatile.Read(ref _maxInFlight);
+
+    public Task<UploadFileResponse> UploadAsync(FileUploaderSlice slice, FileStorageLocation storageLocation, CancellationToken cancellationToken)
+    {
+        var taskId = Environment.CurrentManagedThreadId;
+        return UploadRecordedAsync(slice, storageLocation, taskId, cancellationToken);
+    }
+
+    private static async Task<UploadFileResponse> UploadRecordedAsync(FileUploaderSlice slice, FileStorageLocation storageLocation, int taskId, CancellationToken cancellationToken)
+    {
+        var now = Interlocked.Increment(ref _inFlight);
+        while (true)
+        {
+            var snapshot = Volatile.Read(ref _maxInFlight);
+            if (now > snapshot)
+            {
+                Interlocked.CompareExchange(ref _maxInFlight, now, snapshot);
+                if (Volatile.Read(ref _maxInFlight) >= now) break;
+            }
+            else break;
+        }
+        try
+        {
+            await Task.Delay(50, cancellationToken);
+            lock (Sync)
+            {
+                var sharedId = storageLocation.Url;
+                if (!Records.ContainsKey(sharedId))
+                {
+                    Records[sharedId] = new List<(int, long, int)>();
+                }
+                Records[sharedId].Add((slice.PartNumber, slice.MemoryStream?.Length ?? 0L, taskId));
+            }
+            return UploadFileResponse.Success(200);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _inFlight);
+        }
+    }
+}
+
+

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
@@ -2,6 +2,9 @@ using ByteSync.Services.Communications.Transfers.Uploading;
 using Microsoft.Extensions.Logging.Abstractions;
 using FluentAssertions;
 using NUnit.Framework;
+using Moq;
+using ByteSync.Interfaces.Services.Sessions;
+using ByteSync.Common.Business.Sessions;
 
 namespace ByteSync.Tests.Services.Communications.Transfers.Uploading;
 
@@ -13,7 +16,9 @@ public class AdaptiveUploadControllerTests
     [SetUp]
     public void SetUp()
     {
-        _controller = new AdaptiveUploadController(NullLogger<AdaptiveUploadController>.Instance);
+        var sessionService = new Mock<ISessionService>();
+        sessionService.SetupGet(s => s.SessionObservable).Returns(System.Reactive.Linq.Observable.Return<AbstractSession?>(null));
+        _controller = new AdaptiveUploadController(NullLogger<AdaptiveUploadController>.Instance, sessionService.Object);
     }
 
     [Test]

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
@@ -1,3 +1,4 @@
+using ByteSync.Business.Sessions;
 using ByteSync.Services.Communications.Transfers.Uploading;
 using Microsoft.Extensions.Logging.Abstractions;
 using FluentAssertions;
@@ -18,6 +19,7 @@ public class AdaptiveUploadControllerTests
     {
         var sessionService = new Mock<ISessionService>();
         sessionService.SetupGet(s => s.SessionObservable).Returns(System.Reactive.Linq.Observable.Return<AbstractSession?>(null));
+        sessionService.SetupGet(s => s.SessionStatusObservable).Returns(System.Reactive.Linq.Observable.Never<SessionStatus>());
         _controller = new AdaptiveUploadController(NullLogger<AdaptiveUploadController>.Instance, sessionService.Object);
     }
 

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorFactoryTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadProcessorFactoryTests.cs
@@ -29,7 +29,8 @@ public class FileUploadProcessorFactoryTests
     private Mock<ISessionService> _mockSessionService = null!;
     private Mock<IAdaptiveUploadController> _mockAdaptiveController = null!;
     private Mock<IFileUploadProcessor> _mockProcessor = null!;
-
+    private Mock<IUploadSlicingManager> _mockSlicingManager = null!;
+    
     private FileUploadProcessorFactory _factory = null!;
 
     private SharedFileDefinition _sharedFileDefinition = null!;
@@ -47,6 +48,7 @@ public class FileUploadProcessorFactoryTests
         _mockSessionService = new Mock<ISessionService>();
         _mockAdaptiveController = new Mock<IAdaptiveUploadController>();
         _mockProcessor = new Mock<IFileUploadProcessor>();
+        _mockSlicingManager = new Mock<IUploadSlicingManager>();
 
         _sharedFileDefinition = new SharedFileDefinition
         {
@@ -66,6 +68,7 @@ public class FileUploadProcessorFactoryTests
         builder.RegisterInstance(_mockStrategies.Object).As<IIndex<StorageProvider, IUploadStrategy>>();
         builder.RegisterInstance(_mockSessionService.Object).As<ISessionService>();
         builder.RegisterInstance(_mockAdaptiveController.Object).As<IAdaptiveUploadController>();
+        builder.RegisterInstance(_mockSlicingManager.Object).As<IUploadSlicingManager>();
         // Register the processor as an instance so typed parameters are ignored
         builder.RegisterInstance(_mockProcessor.Object).As<IFileUploadProcessor>();
 


### PR DESCRIPTION
### Summary
Introduces a centralized slicing queue to enforce FIFO ordering and bounded concurrency across uploads, and resets adaptive upload parameters on session changes.

### Key changes
- **New `UploadSlicingManager`**: Adds `IUploadSlicingManager` and `UploadSlicingManager` using a `Channel<Func<Task>>`, FIFO processing, and max concurrency of 2; ignores stale work after session resets.
- **Session-aware adaptive reset**: `AdaptiveUploadController` subscribes to `ISessionService.SessionObservable` and fully resets chunk size, parallelism, and window.
- **DI and factory wiring**: Registers `AdaptiveUploadController` and `UploadSlicingManager` in `SingletonsModule`; resolves and injects `IUploadSlicingManager` in `FileUploadProcessorFactory`.
- **Processor integration**: `FileUploadProcessor` enqueues slicing via `IUploadSlicingManager` instead of starting it directly to ensure ordered execution.
- **Tests updated**: Adjusts unit tests to use `SliceAndEncryptAdaptiveAsync`, injects and stubs `IUploadSlicingManager`, and wires `ISessionService` mock for the controller.

### Rationale
- **Problem**: Parallel slicers could interleave across files, causing contention and non-deterministic ordering; adaptive state leaked across sessions.
- **Solution**: Centralize slicing with FIFO + bounded concurrency and reset adaptive state on session change.

### Notes
- **Backward compatibility**: No public API changes; behavior is more predictable under load.
- **Configurability**: `MAX_CONCURRENT_SLICES` is set to 2 and can be tuned later.