### PR TITLE
[feature] Load environment variables in test configuration

### DIFF
--- a/tests/ByteSync.Client.IntegrationTests/GlobalTestSetup.cs
+++ b/tests/ByteSync.Client.IntegrationTests/GlobalTestSetup.cs
@@ -17,7 +17,8 @@ public class GlobalTestSetup
     public void RunBeforeAnyTests()
     {
         Configuration = new ConfigurationBuilder()
-            .AddJsonFile("client-integration-tests.local.settings.json", optional: false)
+            .AddJsonFile("client-integration-tests.local.settings.json", optional: true)
+            .AddEnvironmentVariables()
             .Build();
 
         var builder = new ContainerBuilder();

--- a/tests/ByteSync.Functions.IntegrationTests/GlobalTestSetup.cs
+++ b/tests/ByteSync.Functions.IntegrationTests/GlobalTestSetup.cs
@@ -23,7 +23,8 @@ public class GlobalTestSetup
         ByteSyncServerCommonAssembly = GetReferencedAssemblyByName("ByteSync.ServerCommon");
         
         Configuration = new ConfigurationBuilder()
-            .AddJsonFile("functions-integration-tests.local.settings.json", optional: false)
+            .AddJsonFile("functions-integration-tests.local.settings.json", optional: true)
+            .AddEnvironmentVariables()
             .Build();
         
         var builder = new ContainerBuilder();

--- a/tests/ByteSync.ServerCommon.Tests/Helpers/TestSettingsInitializer.cs
+++ b/tests/ByteSync.ServerCommon.Tests/Helpers/TestSettingsInitializer.cs
@@ -12,7 +12,8 @@ public class TestSettingsInitializer
     public IConfiguration InitConfiguration()
     {
         var config = new ConfigurationBuilder()
-            .AddJsonFile("server-common-tests.local.settings.json", optional: false)
+            .AddJsonFile("server-common-tests.local.settings.json", optional: true)
+            .AddEnvironmentVariables()
             .Build();
 
         return config;


### PR DESCRIPTION
## Summary
- allow client integration tests to read config from environment
- permit functions integration tests to load env vars and ignore missing local settings
- let server common tests pull settings from environment variables

## Testing
- `dotnet build --verbosity quiet /property:WarningLevel=0`
- `dotnet test` *(fails: configuration is empty; Docker unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b843fd1a0883338b2c73efcb0b70df