### PR TITLE
[fix] Make adaptive upload controller thread-safe and clamp chunk sizes

### DIFF
--- a/src/ByteSync.Client/DependencyInjection/Modules/SingletonsModule.cs
+++ b/src/ByteSync.Client/DependencyInjection/Modules/SingletonsModule.cs
@@ -37,7 +37,7 @@ public class SingletonsModule : Module
         builder.RegisterType<SynchronizationActionServerInformer>().SingleInstance().AsImplementedInterfaces();
         builder.RegisterType<DownloadManager>().SingleInstance().AsImplementedInterfaces();
 
-        builder.RegisterType<AdaptiveUploadController>().SingleInstance().As<IAdaptiveUploadController>();
-        builder.RegisterType<UploadSlicingManager>().SingleInstance().As<IUploadSlicingManager>();
+        builder.RegisterType<AdaptiveUploadController>().SingleInstance().AsImplementedInterfaces();
+        builder.RegisterType<UploadSlicingManager>().SingleInstance().AsImplementedInterfaces();
     }
 }

--- a/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadWorkerMetricsTests.cs
+++ b/tests/ByteSync.Client.Tests/Services/Communications/Transfers/Uploading/FileUploadWorkerMetricsTests.cs
@@ -83,7 +83,7 @@ public class FileUploadWorkerMetricsTests
     }
 
     [Test]
-    public async Task UploadAvailableSlicesAsync_OnError_ShouldAccumulateExceptions()
+    public async Task UploadAvailableSlicesAdaptiveAsync_OnError_ShouldAccumulateExceptions()
     {
         // Arrange
         var slice = new FileUploaderSlice(1, new MemoryStream(new byte[128]));
@@ -94,7 +94,7 @@ public class FileUploadWorkerMetricsTests
         _availableSlices.Writer.Complete();
 
         // Act
-        await _fileUploadWorker.UploadAvailableSlicesAsync(_availableSlices, _progressState);
+        await _fileUploadWorker.UploadAvailableSlicesAdaptiveAsync(_availableSlices, _progressState);
 
         // Assert
         _progressState.Exceptions.Should().NotBeNull();

--- a/tests/ByteSync.Client.Tests/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.Tests/Uploading/AdaptiveUploadControllerTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Reactive.Linq;
+using ByteSync.Common.Business.Sessions;
+using ByteSync.Business.Sessions;
+using ByteSync.Interfaces.Services.Sessions;
+using ByteSync.Services.Communications.Transfers.Uploading;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace ByteSync.Tests.Uploading;
+
+[TestFixture]
+public class AdaptiveUploadControllerTests
+{
+    private static IObservable<T> Empty<T>() => Observable.Empty<T>();
+
+    private static AdaptiveUploadController CreateController()
+    {
+        var logger = new Mock<ILogger<AdaptiveUploadController>>().Object;
+        var sessionService = new Mock<ISessionService>();
+        sessionService.SetupGet(s => s.SessionObservable).Returns(Empty<AbstractSession?>());
+        sessionService.SetupGet(s => s.SessionStatusObservable).Returns(Empty<SessionStatus>());
+        return new AdaptiveUploadController(logger, sessionService.Object);
+    }
+
+    [Test]
+    public void Initial_state_should_be_defaults()
+    {
+        var c = CreateController();
+        c.CurrentChunkSizeBytes.Should().Be(500 * 1024);
+        c.CurrentParallelism.Should().Be(2);
+    }
+
+    [Test]
+    public void Upscale_should_increase_chunk_when_window_fast_and_successful()
+    {
+        var c = CreateController();
+        var before = c.CurrentChunkSizeBytes;
+
+        c.RecordUploadResult(TimeSpan.FromSeconds(5), true, partNumber: 1);
+        c.RecordUploadResult(TimeSpan.FromSeconds(6), true, partNumber: 2);
+
+        c.CurrentChunkSizeBytes.Should().BeGreaterThan(before);
+        c.CurrentParallelism.Should().Be(2);
+    }
+
+    [Test]
+    public void Downscale_should_reduce_chunk_when_slow_and_at_min_parallelism()
+    {
+        var c = CreateController();
+
+        c.RecordUploadResult(TimeSpan.FromSeconds(35), true, partNumber: 1);
+        c.RecordUploadResult(TimeSpan.FromSeconds(36), true, partNumber: 2);
+
+        // 500 KB * 0.75 = 375 KB
+        c.CurrentChunkSizeBytes.Should().Be(375 * 1024);
+        c.CurrentParallelism.Should().Be(2);
+    }
+
+    [Test]
+    public void Error_code_should_reset_chunk_to_initial()
+    {
+        var c = CreateController();
+
+        c.RecordUploadResult(TimeSpan.FromSeconds(1), true, partNumber: 1);
+        c.RecordUploadResult(TimeSpan.FromSeconds(1), true, partNumber: 2);
+        c.CurrentChunkSizeBytes.Should().BeGreaterThan(500 * 1024);
+
+        c.RecordUploadResult(TimeSpan.FromSeconds(1), false, partNumber: 3, statusCode: 429);
+        c.CurrentChunkSizeBytes.Should().Be(500 * 1024);
+    }
+
+    [Test]
+    public void Chunk_size_should_never_exceed_upper_bound()
+    {
+        var c = CreateController();
+        for (int i = 0; i < 200; i++)
+        {
+            var p = c.CurrentParallelism;
+            for (int j = 0; j < p; j++)
+            {
+                c.RecordUploadResult(TimeSpan.FromSeconds(1), true, partNumber: i * 10 + j);
+            }
+        }
+
+        c.CurrentChunkSizeBytes.Should().BeLessThanOrEqualTo(16 * 1024 * 1024);
+    }
+}


### PR DESCRIPTION
Summary
- Add locking around adaptive state updates/reads
- Clamp chunk size between 64 KB and 16 MB
- Reset measurement window on bandwidth error reset and after parallelism changes
- Remove unused state and tighten logs
- Add unit tests for upscale/downscale/error reset and bounds

Details
- src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs: protects mutable state via a private lock, clamps chunk sizes, resets window appropriately, and removes unused _recentPartNumbers
- tests/ByteSync.Client.Tests/Uploading/AdaptiveUploadControllerTests.cs: adds targeted NUnit + FluentAssertions tests

Validation
- dotnet build ByteSync.sln (Debug) succeeded
- dotnet test tests/ByteSync.Client.Tests (Debug, no-build) -> 636 tests green including new tests

Notes
- Scope kept minimal; no changes to APIs or runtime behavior beyond thread-safety and bounds.