### PR TITLE
Fix background thread ui access in tests

### DIFF
--- a/src/ByteSync.Client/ViewModels/Misc/FlyoutContainerViewModel.cs
+++ b/src/ByteSync.Client/ViewModels/Misc/FlyoutContainerViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -108,16 +108,16 @@ public class FlyoutContainerViewModel : ActivatableViewModelBase, IDialogView
         if (Dispatcher.UIThread.CheckAccess())
         {
             ShowFlyout(messageBoxViewModel.TitleKey, false, messageBoxViewModel);
-            return await messageBoxViewModel.WaitForResponse();
         }
         else
         {
-            return await Dispatcher.UIThread.InvokeAsync(async () =>
+            await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 ShowFlyout(messageBoxViewModel.TitleKey, false, messageBoxViewModel);
-                return await messageBoxViewModel.WaitForResponse();
             });
         }
+
+        return await messageBoxViewModel.WaitForResponse();
     }
     
     [ExcludeFromCodeCoverage]


### PR DESCRIPTION
Refactor `ShowMessageBoxAsync` to correctly marshal UI-bound calls to the dispatcher, fixing an `InvalidOperationException`.

The previous implementation of `ShowMessageBoxAsync` was awaiting `messageBoxViewModel.WaitForResponse()` inside `Dispatcher.UIThread.InvokeAsync`. This caused a `System.InvalidOperationException` due to `Avalonia.Threading.Dispatcher.VerifyAccess()` failing when the background thread tried to block on the UI thread's dispatcher while also trying to run an async operation on it. By moving `WaitForResponse()` outside the `InvokeAsync` call, only the `ShowFlyout` method (which requires UI thread access) is executed on the dispatcher, allowing the calling thread to await the response without blocking the UI thread or violating dispatcher access rules.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d7b6739-8657-42e2-a823-79e9b1af2f58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d7b6739-8657-42e2-a823-79e9b1af2f58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

