### PR TITLE
[feature] Bounded channel backpressure for upload slices

### DIFF
--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
@@ -12,12 +12,19 @@ public class FileUploadCoordinator : IFileUploadCoordinator
     private readonly ManualResetEvent _uploadingIsFinished;
     private readonly ManualResetEvent _exceptionOccurred;
     private readonly ILogger<FileUploadCoordinator> _logger;
+    private const int CHANNEL_CAPACITY = 8;
 
     public FileUploadCoordinator(ILogger<FileUploadCoordinator> logger)
     {
         _logger = logger;
         _syncRoot = new object();
-        _availableSlices = Channel.CreateUnbounded<FileUploaderSlice>();
+        var options = new BoundedChannelOptions(CHANNEL_CAPACITY)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleWriter = true,
+            SingleReader = false
+        };
+        _availableSlices = Channel.CreateBounded<FileUploaderSlice>(options);
         _uploadingIsFinished = new ManualResetEvent(false);
         _exceptionOccurred = new ManualResetEvent(false);
     }


### PR DESCRIPTION
This pull request refactors how file slices are managed and delivered for upload, focusing on improving backpressure handling and error propagation. The main changes include switching from an unbounded to a bounded channel for slice delivery, removing manual polling logic for backpressure, and ensuring exceptions are properly signaled to consumers.

**Channel and Backpressure Improvements:**

* Switched `_availableSlices` from an unbounded to a bounded channel with a capacity of 8, enabling better control over memory usage and upload flow. The channel is configured for single writer and multiple readers, and will block when full until space is available. (`FileUploadCoordinator.cs`)
* Removed manual polling logic for backpressure in `SliceAndEncryptAdaptiveAsync`. Backpressure is now handled automatically by the bounded channel, simplifying the code and improving efficiency. (`FileSlicer.cs`)

**Error Handling Enhancements:**

* Updated both `SliceAndEncryptAsync` and `SliceAndEncryptAdaptiveAsync` to call `_availableSlices.Writer.TryComplete(ex)` when an exception occurs, ensuring downstream consumers are notified of errors and can respond appropriately. (`FileSlicer.cs`) [[1]](diffhunk://#diff-b6484741303ae042ac85259e711d002b48eac91e8dcb9a148ceafadd6352603dR89) [[2]](diffhunk://#diff-b6484741303ae042ac85259e711d002b48eac91e8dcb9a148ceafadd6352603dR152)