### PR TITLE
[feature] Add Redis SSL toggle and guard integration tests

### DIFF
--- a/src/ByteSync.ServerCommon/Business/Settings/RedisSettings.cs
+++ b/src/ByteSync.ServerCommon/Business/Settings/RedisSettings.cs
@@ -3,6 +3,8 @@
 public class RedisSettings
 {
     public string ConnectionString { get; set; } = "";
-    
+
     public string Prefix { get; set; } = "";
+
+    public bool UseSsl { get; set; } = true;
 }

--- a/src/ByteSync.ServerCommon/Services/RedisInfrastructureService.cs
+++ b/src/ByteSync.ServerCommon/Services/RedisInfrastructureService.cs
@@ -19,6 +19,7 @@ public class RedisInfrastructureService : IRedisInfrastructureService
     private readonly ICacheKeyFactory _cacheKeyFactory;
     private readonly RedLockFactory _redLockFactory;
     private static string? _cachedConnectionString;
+    private static bool? _cachedUseSsl;
     private readonly ConnectionMultiplexer _connectionMultiplexer;
 
     public RedisInfrastructureService(IOptions<RedisSettings> redisSettings, ICacheKeyFactory cacheKeyFactory, ILoggerFactory loggerFactory)
@@ -27,6 +28,7 @@ public class RedisInfrastructureService : IRedisInfrastructureService
         _cacheKeyFactory = cacheKeyFactory;
         
         _cachedConnectionString ??= _redisSettings.ConnectionString;
+        _cachedUseSsl ??= _redisSettings.UseSsl;
 
         _connectionMultiplexer = _lazyMultiplexer.Value;
 
@@ -42,8 +44,8 @@ public class RedisInfrastructureService : IRedisInfrastructureService
     private static readonly Lazy<ConnectionMultiplexer> _lazyMultiplexer = new(() =>
     {
         var options = ConfigurationOptions.Parse(_cachedConnectionString!);
-        
-        options.Ssl = true;
+
+        options.Ssl = _cachedUseSsl ?? true;
         options.AbortOnConnectFail = false;
         
         if (options.ConnectTimeout < 10000)

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2DownloadResume_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2DownloadResume_Tests.cs
@@ -35,6 +35,17 @@ public class R2DownloadResume_Tests
             ServiceRegistrar.RegisterComponents();
         }
 
+        var cloudflareSettings = GlobalTestSetup.Container
+            .Resolve<Microsoft.Extensions.Options.IOptions<CloudflareR2Settings>>().Value;
+
+        if (string.IsNullOrWhiteSpace(cloudflareSettings.Endpoint)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.AccessKeyId)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.SecretAccessKey)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.BucketName))
+        {
+            Assert.Ignore("Cloudflare R2 settings are not configured for integration tests.");
+        }
+
         _clientScope = ByteSync.Services.ContainerProvider.Container!.BeginLifetimeScope(b =>
         {
             // Simulate one GET 500 during download by replacing IHttpClientFactory used by strategies
@@ -57,7 +68,7 @@ public class R2DownloadResume_Tests
     [TearDown]
     public void TearDown()
     {
-        _clientScope.Dispose();
+        _clientScope?.Dispose();
     }
 
     [Test]

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2UploadDownload_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2UploadDownload_Tests.cs
@@ -32,6 +32,17 @@ public class R2UploadDownload_Tests
             ServiceRegistrar.RegisterComponents();
         }
 
+        var cloudflareSettings = GlobalTestSetup.Container
+            .Resolve<Microsoft.Extensions.Options.IOptions<ByteSync.ServerCommon.Business.Settings.CloudflareR2Settings>>().Value;
+
+        if (string.IsNullOrWhiteSpace(cloudflareSettings.Endpoint)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.AccessKeyId)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.SecretAccessKey)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.BucketName))
+        {
+            Assert.Ignore("Cloudflare R2 settings are not configured for integration tests.");
+        }
+
         _clientScope = ByteSync.Services.ContainerProvider.Container!.BeginLifetimeScope(b =>
         {
             b.RegisterType<CloudflareR2ClientFactory>().As<ICloudflareR2ClientFactory>().SingleInstance();
@@ -50,7 +61,7 @@ public class R2UploadDownload_Tests
     [TearDown]
     public void TearDown()
     {
-        _clientScope.Dispose();
+        _clientScope?.Dispose();
     }
 
     [Test]

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2UploadResume_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2UploadResume_Tests.cs
@@ -28,6 +28,17 @@ public class R2UploadResume_Tests
             ServiceRegistrar.RegisterComponents();
         }
 
+        var cloudflareSettings = GlobalTestSetup.Container
+            .Resolve<Microsoft.Extensions.Options.IOptions<CloudflareR2Settings>>().Value;
+
+        if (string.IsNullOrWhiteSpace(cloudflareSettings.Endpoint)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.AccessKeyId)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.SecretAccessKey)
+            || string.IsNullOrWhiteSpace(cloudflareSettings.BucketName))
+        {
+            Assert.Ignore("Cloudflare R2 settings are not configured for integration tests.");
+        }
+
         _clientScope = ByteSync.Services.ContainerProvider.Container!.BeginLifetimeScope(b =>
         {
             // Override IHttpClientFactory used by strategies with a flaky handler to simulate 500 once
@@ -50,7 +61,7 @@ public class R2UploadResume_Tests
     [TearDown]
     public void TearDown()
     {
-        _clientScope.Dispose();
+        _clientScope?.Dispose();
     }
 
     [Test]

--- a/tests/ByteSync.Functions.IntegrationTests/End2End/E2E_Auth_Session_Tests.cs
+++ b/tests/ByteSync.Functions.IntegrationTests/End2End/E2E_Auth_Session_Tests.cs
@@ -28,10 +28,22 @@ public class E2E_Auth_Session_Tests
     [OneTimeTearDown]
     public async Task OneTimeTeardown()
     {
-        await _initializer.Functions.DisposeAsync();
-        await _initializer.Azurite.DisposeAsync();
-        _initializer.Http.Dispose();
-        _api.Dispose();
+        if (_initializer != null)
+        {
+            if (_initializer.Functions != null)
+            {
+                await _initializer.Functions.DisposeAsync();
+            }
+
+            if (_initializer.Azurite != null)
+            {
+                await _initializer.Azurite.DisposeAsync();
+            }
+
+            _initializer.Http?.Dispose();
+        }
+
+        _api?.Dispose();
     }
 
     [Test]

--- a/tests/ByteSync.Functions.IntegrationTests/End2End/E2E_Environment_Setup.cs
+++ b/tests/ByteSync.Functions.IntegrationTests/End2End/E2E_Environment_Setup.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
 using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
 using ContainerBuilder = DotNet.Testcontainers.Builders.ContainerBuilder;
 using IContainer = DotNet.Testcontainers.Containers.IContainer;
 using FluentAssertions;
+using NUnit.Framework;
 
 namespace ByteSync.Functions.IntegrationTests.End2End;
 
@@ -14,6 +16,11 @@ public class E2E_Environment_Setup
 
     public async Task InitializeAsync()
     {
+        if (TestcontainersSettings.OS.DockerEndpointAuthConfig == null)
+        {
+            Assert.Ignore("Docker endpoint is not available for Testcontainers.");
+        }
+
         Azurite = new ContainerBuilder()
             .WithImage("mcr.microsoft.com/azure-storage/azurite")
             .WithName($"bytesync-azurite-e2e-{Guid.NewGuid():N}")

--- a/tests/ByteSync.Functions.IntegrationTests/functions-integration-tests.local.settings.template.json
+++ b/tests/ByteSync.Functions.IntegrationTests/functions-integration-tests.local.settings.template.json
@@ -1,7 +1,8 @@
 ﻿{
   "Redis": {
     "ConnectionString": "",
-    "Prefix": ""
+    "Prefix": "",
+    "UseSsl": true
   },
   "AzureBlobStorage": {
     "Endpoint": "",

--- a/tests/ByteSync.ServerCommon.Tests/server-common-tests.local.settings.template.json
+++ b/tests/ByteSync.ServerCommon.Tests/server-common-tests.local.settings.template.json
@@ -1,7 +1,8 @@
 ﻿{
   "Redis": {
     "ConnectionString": "",
-    "Prefix": ""
+    "Prefix": "",
+    "UseSsl": true
   },
   "AzureBlobStorage": {
     "Endpoint": "",


### PR DESCRIPTION
## Summary
- add a configurable `UseSsl` flag to Redis settings and reuse it when constructing the multiplexer
- document the new flag in local settings templates so developers can disable SSL when running locally
- update Cloudflare R2 and Azure-dependent integration tests to skip cleanly when credentials or Docker are unavailable, and ensure disposals are resilient

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2962f280c83339739fe313632a11a