### PR TITLE
[chore] Improve FilterParser syntax on Linux

### DIFF
--- a/src/ByteSync.Client/Business/Filtering/Parsing/FilterParser.cs
+++ b/src/ByteSync.Client/Business/Filtering/Parsing/FilterParser.cs
@@ -53,7 +53,7 @@ public class FilterParser : IFilterParser
     private bool IsComplexExpression(string filterText)
     {
         // Split by whitespace to analyze individual terms
-        var terms = filterText.Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        var terms = filterText.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         
         return terms.Any(term =>
             
@@ -93,7 +93,7 @@ public class FilterParser : IFilterParser
     /// </summary>
     private ParseResult CreateTextSearchExpression(string filterText)
     {
-        var terms = filterText.Split([' '], StringSplitOptions.RemoveEmptyEntries);
+        var terms = filterText.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         
         FilterExpression compositeExpression = new TrueExpression();
         foreach (var term in terms)


### PR DESCRIPTION
This pull request updates the way string splitting is performed in the `FilterParser.cs` file to improve compatibility and clarity. The main change is switching from array literal syntax to explicit array construction when splitting filter text by spaces.

String splitting compatibility improvements:

* Updated `IsComplexExpression` and `CreateTextSearchExpression` methods to use `filterText.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)` instead of `filterText.Split([' '], StringSplitOptions.RemoveEmptyEntries)` for splitting terms by whitespace. [[1]](diffhunk://#diff-7f01da0d20d7d213d1d20f4c0a6d5541d0f4aa3ad77035955c89c6173450e83cL56-R56) [[2]](diffhunk://#diff-7f01da0d20d7d213d1d20f4c0a6d5541d0f4aa3ad77035955c89c6173450e83cL96-R96)