### PR TITLE
[fix] Surface identification errors in inventory stats

### DIFF
--- a/src/ByteSync.Client/Assets/Resources/Resources.fr.resx
+++ b/src/ByteSync.Client/Assets/Resources/Resources.fr.resx
@@ -394,6 +394,9 @@ Voulez-vous continuer ?</value>
 	<data name="InventoryProcess_IdentifiedDirectories" xml:space="preserve">
 		<value>Répertoires identifiés :</value>
 	</data>
+	<data name="InventoryProcess_IdentificationErrors" xml:space="preserve">
+		<value>Erreurs d'identification :</value>
+	</data>
 	<data name="InventoryProcess_Start" xml:space="preserve">
 		<value>Démarrage :</value>
 	</data>
@@ -666,6 +669,9 @@ Voulez-vous continuer ?</value>
     </data>
     <data name="InventoryProcess_GlobalAnalyzeErrors" xml:space="preserve">
         <value>Total des erreurs de calcul :</value>
+    </data>
+    <data name="InventoryProcess_GlobalIdentificationErrors" xml:space="preserve">
+        <value>Total erreurs d'identification :</value>
     </data>
 	<data name="ContentIdentity_AnErrorOccured" xml:space="preserve">
 		<value>Une erreur est survenue durant l'analyse</value>

--- a/src/ByteSync.Client/Assets/Resources/Resources.resx
+++ b/src/ByteSync.Client/Assets/Resources/Resources.resx
@@ -394,6 +394,9 @@ Would you like to continue ?</value>
 	<data name="InventoryProcess_IdentifiedDirectories" xml:space="preserve">
 		<value>Identified Directories:</value>
 	</data>
+	<data name="InventoryProcess_IdentificationErrors" xml:space="preserve">
+		<value>Identification Errors:</value>
+	</data>
 	<data name="InventoryProcess_Start" xml:space="preserve">
 		<value>Start:</value>
 	</data>
@@ -670,11 +673,14 @@ Would you like to continue ?</value>
     <data name="InventoryProcess_GlobalProcessedSize" xml:space="preserve">
         <value>Total Processed Volume:</value>
     </data>
-    <data name="InventoryProcess_GlobalAnalyzeSuccess" xml:space="preserve">
-        <value>Total Successful Calculations:</value>
-    </data>
-    <data name="InventoryProcess_GlobalAnalyzeErrors" xml:space="preserve">
-        <value>Total Calculation Errors:</value>
+	<data name="InventoryProcess_GlobalAnalyzeSuccess" xml:space="preserve">
+		<value>Total Successful Calculations:</value>
+	</data>
+	<data name="InventoryProcess_GlobalAnalyzeErrors" xml:space="preserve">
+		<value>Total Calculation Errors:</value>
+	</data>
+    <data name="InventoryProcess_GlobalIdentificationErrors" xml:space="preserve">
+        <value>Total Identification Errors:</value>
     </data>
 	<data name="ContentIdentity_AnErrorOccured" xml:space="preserve">
 		<value>An error has occurred during the analysis</value>

--- a/src/ByteSync.Client/Business/Inventories/InventoryMonitorData.cs
+++ b/src/ByteSync.Client/Business/Inventories/InventoryMonitorData.cs
@@ -12,6 +12,8 @@ public record InventoryMonitorData
     
     public int AnalyzeErrors { get; set; }
     
+    public int IdentificationErrors { get; set; }
+    
     public int AnalyzableFiles { get; set; }
     
     public long AnalyzableVolume { get; set; }
@@ -29,6 +31,7 @@ public record InventoryMonitorData
                || AnalyzedFiles != 0
                || ProcessedVolume != 0
                || AnalyzeErrors != 0
+               || IdentificationErrors != 0
                || AnalyzableFiles != 0
                || AnalyzableVolume != 0
                || IdentifiedVolume != 0

--- a/src/ByteSync.Client/Business/Inventories/InventoryStatistics.cs
+++ b/src/ByteSync.Client/Business/Inventories/InventoryStatistics.cs
@@ -6,7 +6,9 @@ public record InventoryStatistics
     
     public long ProcessedVolume { get; init; }
     
-    public int Success { get; init; }
+    public int AnalyzeSuccess { get; init; }
     
-    public int Errors { get; init; }
+    public int AnalyzeErrors { get; init; }
+    
+    public int IdentificationErrors { get; init; }
 }

--- a/src/ByteSync.Client/Services/Inventories/InventoryBuilder.cs
+++ b/src/ByteSync.Client/Services/Inventories/InventoryBuilder.cs
@@ -542,13 +542,25 @@ public class InventoryBuilder : IInventoryBuilder
                     {
                         imd.IdentifiedVolume += fileDescription.Size;
                     }
+                    else
+                    {
+                        imd.IdentificationErrors += 1;
+                    }
                     
                     imd.IdentifiedFiles += 1;
                 });
             }
             else
             {
-                InventoryProcessData.UpdateMonitorData(imd => imd.IdentifiedDirectories += 1);
+                InventoryProcessData.UpdateMonitorData(imd =>
+                {
+                    if (!fileSystemDescription.IsAccessible)
+                    {
+                        imd.IdentificationErrors += 1;
+                    }
+                    
+                    imd.IdentifiedDirectories += 1;
+                });
             }
         }
     }

--- a/src/ByteSync.Client/Services/Inventories/InventoryStatisticsService.cs
+++ b/src/ByteSync.Client/Services/Inventories/InventoryStatisticsService.cs
@@ -64,8 +64,9 @@ public class InventoryStatisticsService : IInventoryStatisticsService
         {
             TotalAnalyzed = statsCollector.TotalAnalyzed,
             ProcessedVolume = statsCollector.ProcessedSize,
-            Success = statsCollector.Success,
-            Errors = statsCollector.Errors
+            AnalyzeSuccess = statsCollector.Success,
+            AnalyzeErrors = statsCollector.Errors,
+            IdentificationErrors = statsCollector.IdentificationErrors
         };
         
         _statisticsSubject.OnNext(stats);
@@ -80,8 +81,22 @@ public class InventoryStatisticsService : IInventoryStatisticsService
             
             foreach (var part in inventory.InventoryParts)
             {
+                foreach (var dir in part.DirectoryDescriptions)
+                {
+                    if (!dir.IsAccessible)
+                    {
+                        collector.IdentificationErrors += 1;
+                    }
+                }
+                
                 foreach (var fd in part.FileDescriptions)
                 {
+                    if (!fd.IsAccessible)
+                    {
+                        collector.IdentificationErrors += 1;
+                        continue;
+                    }
+                    
                     ProcessFileDescription(fd, collector);
                 }
             }
@@ -125,6 +140,8 @@ public class InventoryStatisticsService : IInventoryStatisticsService
         public int Success { get; set; }
         
         public int Errors { get; set; }
+        
+        public int IdentificationErrors { get; set; }
         
         public long ProcessedSize { get; set; }
     }

--- a/src/ByteSync.Client/ViewModels/Sessions/Inventories/InventoryLocalIdentificationViewModel.cs
+++ b/src/ByteSync.Client/ViewModels/Sessions/Inventories/InventoryLocalIdentificationViewModel.cs
@@ -51,7 +51,13 @@ public class InventoryLocalIdentificationViewModel : ActivatableViewModelBase
                 IdentifiedFiles = m.IdentifiedFiles;
                 IdentifiedDirectories = m.IdentifiedDirectories;
                 IdentifiedVolume = m.IdentifiedVolume;
+                IdentificationErrors = m.IdentificationErrors;
             })
+            .DisposeWith(disposables);
+        
+        this.WhenAnyValue(x => x.IdentificationErrors)
+            .Select(v => v > 0)
+            .ToPropertyEx(this, x => x.HasIdentificationErrors)
             .DisposeWith(disposables);
         
         _inventoryService.InventoryProcessData.IdentificationStatus
@@ -124,6 +130,11 @@ public class InventoryLocalIdentificationViewModel : ActivatableViewModelBase
     
     [Reactive]
     public long IdentifiedVolume { get; set; }
+    
+    [Reactive]
+    public int IdentificationErrors { get; set; }
+    
+    public extern bool HasIdentificationErrors { [ObservableAsProperty] get; }
     
     [Reactive]
     public string IdentificationIcon { get; set; } = "None";

--- a/src/ByteSync.Client/Views/Sessions/Inventories/InventoryGlobalStatusView.axaml
+++ b/src/ByteSync.Client/Views/Sessions/Inventories/InventoryGlobalStatusView.axaml
@@ -56,6 +56,7 @@
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
             </Grid.RowDefinitions>
 
             <Label Grid.Row="0" Grid.Column="0" Content="{localizations:Loc InventoryProcess_GlobalAnalyzedFiles}"
@@ -77,10 +78,20 @@
                 <TextBlock Text="{Binding GlobalAnalyzeSuccess, FallbackValue=''}" />
             </Border>
 
-            <Label Grid.Row="3" Grid.Column="0" Content="{localizations:Loc InventoryProcess_GlobalAnalyzeErrors}"
+            <Label Grid.Row="3" Grid.Column="0" Content="{localizations:Loc InventoryProcess_GlobalIdentificationErrors}"
+                   Classes="InventoryStatusDescription"
+                   Classes.IsBold="{Binding HasIdentificationErrors}" />
+            <Border Grid.Row="3" Grid.Column="1" HorizontalAlignment="Right"
+                    Classes="Badge"
+                    Classes.Secondary="{Binding HasIdentificationErrors}">
+                <TextBlock Text="{Binding GlobalIdentificationErrors, FallbackValue=''}"
+                           Classes.IsBold="{Binding HasIdentificationErrors}" />
+            </Border>
+
+            <Label Grid.Row="4" Grid.Column="0" Content="{localizations:Loc InventoryProcess_GlobalAnalyzeErrors}"
                    Classes="InventoryStatusDescription"
                    Classes.IsBold="{Binding HasErrors}" />
-            <Border Grid.Row="3" Grid.Column="1" HorizontalAlignment="Right"
+            <Border Grid.Row="4" Grid.Column="1" HorizontalAlignment="Right"
                     Classes="Badge"
                     Classes.Secondary="{Binding HasErrors}">
                 <TextBlock Text="{Binding GlobalAnalyzeErrors, FallbackValue=''}"

--- a/src/ByteSync.Client/Views/Sessions/Inventories/InventoryLocalIdentificationView.axaml
+++ b/src/ByteSync.Client/Views/Sessions/Inventories/InventoryLocalIdentificationView.axaml
@@ -41,6 +41,7 @@
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
             </Grid.RowDefinitions>
 
             <Label Grid.Row="0" Grid.Column="0" Content="{localizations:Loc InventoryProcess_IdentifiedFiles}"
@@ -59,6 +60,16 @@
                    Content="{Binding IdentifiedVolume, FallbackValue=0, 
                         Converter={StaticResource FormatKbSizeConverter}}"
                    HorizontalContentAlignment="Right" />
+
+            <Label Grid.Row="3" Grid.Column="0" Content="{localizations:Loc InventoryProcess_IdentificationErrors}"
+                   Classes="InventoryStatusDescription"
+                   Classes.IsBold="{Binding HasIdentificationErrors}" />
+            <Border Grid.Row="3" Grid.Column="1" HorizontalAlignment="Right"
+                    Classes="Badge"
+                    Classes.Secondary="{Binding HasIdentificationErrors}">
+                <TextBlock Text="{Binding IdentificationErrors, FallbackValue=0}"
+                           Classes.IsBold="{Binding HasIdentificationErrors}" />
+            </Border>
         </Grid>
     </StackPanel>
 </UserControl>

--- a/tests/ByteSync.Client.UnitTests/ViewModels/Sessions/Inventories/InventoryGlobalStatusViewModelTests.cs
+++ b/tests/ByteSync.Client.UnitTests/ViewModels/Sessions/Inventories/InventoryGlobalStatusViewModelTests.cs
@@ -125,7 +125,7 @@ public class InventoryGlobalStatusViewModelTests
         _processData.GlobalMainStatus.OnNext(InventoryTaskStatus.Success);
         vm.IsInventoryInProgress.Should().BeTrue("waiting for final stats");
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 3, Success = 0, TotalAnalyzed = 0 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 3, AnalyzeSuccess = 0, TotalAnalyzed = 0 });
         
         vm.HasErrors.Should().BeTrue();
         vm.IsInventoryInProgress.Should().BeFalse();
@@ -140,7 +140,7 @@ public class InventoryGlobalStatusViewModelTests
         _processData.GlobalMainStatus.OnNext(InventoryTaskStatus.Success);
         vm.IsInventoryInProgress.Should().BeTrue();
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 0, Success = 10, TotalAnalyzed = 10 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 0, AnalyzeSuccess = 10, TotalAnalyzed = 10 });
         
         vm.HasErrors.Should().BeFalse();
         vm.IsInventoryInProgress.Should().BeFalse();
@@ -152,7 +152,7 @@ public class InventoryGlobalStatusViewModelTests
     {
         var vm = CreateVm();
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 2, Success = 0, TotalAnalyzed = 2 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 2, AnalyzeSuccess = 0, TotalAnalyzed = 2 });
         _processData.GlobalMainStatus.OnNext(InventoryTaskStatus.Success);
         
         vm.HasErrors.Should().BeTrue();
@@ -165,7 +165,7 @@ public class InventoryGlobalStatusViewModelTests
     {
         var vm = CreateVm();
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 0, Success = 5, TotalAnalyzed = 5 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 0, AnalyzeSuccess = 5, TotalAnalyzed = 5 });
         _processData.GlobalMainStatus.OnNext(InventoryTaskStatus.Success);
         
         vm.GlobalMainIcon.Should().Be("SolidCheckCircle");
@@ -183,7 +183,7 @@ public class InventoryGlobalStatusViewModelTests
         
         vm.IsInventoryInProgress.Should().BeTrue("waiting for first non-null statistics");
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 0, Success = 3, TotalAnalyzed = 3 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 0, AnalyzeSuccess = 3, TotalAnalyzed = 3 });
         
         vm.GlobalMainIcon.Should().Be("SolidCheckCircle");
         vm.IsInventoryInProgress.Should().BeFalse();
@@ -210,10 +210,10 @@ public class InventoryGlobalStatusViewModelTests
     {
         var vm = CreateVm();
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 4, Success = 0, TotalAnalyzed = 4 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 4, AnalyzeSuccess = 0, TotalAnalyzed = 4 });
         vm.HasErrors.Should().BeTrue();
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 0, Success = 10, TotalAnalyzed = 10 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 0, AnalyzeSuccess = 10, TotalAnalyzed = 10 });
         vm.HasErrors.Should().BeFalse();
     }
     
@@ -222,7 +222,7 @@ public class InventoryGlobalStatusViewModelTests
     {
         var vm = CreateVm();
         
-        _statsSubject.OnNext(new InventoryStatistics { Errors = 1, Success = 2, TotalAnalyzed = 3 });
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 1, AnalyzeSuccess = 2, TotalAnalyzed = 3 });
         vm.GlobalAnalyzeErrors.Should().Be(1);
         
         vm.GlobalMainIcon = "SolidCheckCircle";
@@ -234,8 +234,33 @@ public class InventoryGlobalStatusViewModelTests
         vm.GlobalTotalAnalyzed.Should().Be(null);
         vm.GlobalAnalyzeSuccess.Should().Be(null);
         vm.GlobalAnalyzeErrors.Should().Be(null);
+        vm.GlobalIdentificationErrors.Should().Be(null);
         vm.GlobalMainIcon.Should().Be("None");
         vm.GlobalMainStatusText.Should().BeEmpty();
+    }
+    
+    [Test]
+    public void HasIdentificationErrors_ComputedFromStats()
+    {
+        var vm = CreateVm();
+        
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 0, AnalyzeSuccess = 1, TotalAnalyzed = 1, IdentificationErrors = 2 });
+        vm.HasIdentificationErrors.Should().BeTrue();
+        
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 0, AnalyzeSuccess = 1, TotalAnalyzed = 1, IdentificationErrors = 0 });
+        vm.HasIdentificationErrors.Should().BeFalse();
+    }
+    
+    [Test]
+    public void SuccessWithIdentificationErrors_RendersErrorState()
+    {
+        var vm = CreateVm();
+        
+        _statsSubject.OnNext(new InventoryStatistics { AnalyzeErrors = 0, AnalyzeSuccess = 1, TotalAnalyzed = 1, IdentificationErrors = 1 });
+        _processData.GlobalMainStatus.OnNext(InventoryTaskStatus.Success);
+        
+        vm.HasIdentificationErrors.Should().BeTrue();
+        vm.GlobalMainIcon.Should().Be("RegularError");
     }
     
     [Test]


### PR DESCRIPTION
## Summary
- track and display local and global identification errors (inaccessible files/directories) during inventory
- add identification errors to inventory statistics and success/error visuals
- local/global views now show badges for identification errors when present

## Testing
- dotnet build
- dotnet test