### PR TITLE
[fix] Add legacy ActionOperatorTypes values for backward compatibility

### DIFF
--- a/src/ByteSync.Common/Business/Actions/ActionOperatorTypes.cs
+++ b/src/ByteSync.Common/Business/Actions/ActionOperatorTypes.cs
@@ -3,6 +3,13 @@
 public enum ActionOperatorTypes
 {
     // File only
+    
+    // Keep for backward compatibility
+    // Delete when minimal supported version >= 2026.1
+    SynchronizeContentOnly = 1,
+    SynchronizeDate = 2,
+    SynchronizeContentAndDate = 3, 
+    
     CopyContentOnly = 1,
     CopyDatesOnly = 2,
     Copy = 3,


### PR DESCRIPTION
Summary:\n- Add legacy ActionOperatorTypes names to keep JSON payloads compatible with older clients.\n\nMain changes:\n- Extend ActionOperatorTypes with legacy enum names mapped to existing values.\n\nImplementation approach:\n- Preserve current enum values and add aliases so both old and new names deserialize correctly.