### PR TITLE
[refactor] Replace Path.GetTempPath with AbstractTester in tests

### DIFF
--- a/src/ByteSync.Client/ByteSync.Client.csproj
+++ b/src/ByteSync.Client/ByteSync.Client.csproj
@@ -109,7 +109,6 @@
             <Generator>ResXFileCodeGenerator</Generator>
             <LastGenOutput>Resources.Designer.cs</LastGenOutput>
         </EmbeddedResource>
-        <None Remove="local.settings.json"/>
         <EmbeddedResource Include="local.settings.json"/>
         <EmbeddedResource Include="Services\Inventories\noise-files.json"/>
     </ItemGroup>

--- a/src/ByteSync.Client/ByteSync.Client.csproj
+++ b/src/ByteSync.Client/ByteSync.Client.csproj
@@ -109,6 +109,7 @@
             <Generator>ResXFileCodeGenerator</Generator>
             <LastGenOutput>Resources.Designer.cs</LastGenOutput>
         </EmbeddedResource>
+        <None Remove="local.settings.json"/>
         <EmbeddedResource Include="local.settings.json"/>
         <EmbeddedResource Include="Services\Inventories\noise-files.json"/>
     </ItemGroup>

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2DownloadResume_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2DownloadResume_Tests.cs
@@ -6,6 +6,7 @@ using ByteSync.Client.IntegrationTests.TestHelpers.Http;
 using ByteSync.Common.Business.Actions;
 using ByteSync.Common.Business.Inventories;
 using ByteSync.Common.Business.SharedFiles;
+using ByteSync.TestsCommon;
 using ByteSync.DependencyInjection;
 using ByteSync.Interfaces.Controls.Communications.Http;
 using ByteSync.Interfaces.Factories;
@@ -22,13 +23,14 @@ using ByteSync.Services.Communications.Transfers.Uploading;
 
 namespace ByteSync.Client.IntegrationTests.Services.Communications.Transfers;
 
-public class R2DownloadResume_Tests
+public class R2DownloadResume_Tests : AbstractTester
 {
     private ILifetimeScope _clientScope = null!;
 
     [SetUp]
     public void SetUp()
     {
+        CreateTestDirectory();
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (ByteSync.Services.ContainerProvider.Container == null)
         {
@@ -99,7 +101,7 @@ public class R2DownloadResume_Tests
             Source = new SharedDataPart
             {
                 ClientInstanceId = shared.ClientInstanceId,
-                RootPath = Path.GetTempPath(),
+                RootPath = TestDirectory.FullName,
                 InventoryPartType = FileSystemTypes.File,
                 Name = "itests",
                 InventoryCodeAndId = "itests"
@@ -113,7 +115,7 @@ public class R2DownloadResume_Tests
         sag.Targets.Add(new SharedDataPart
         {
             ClientInstanceId = shared.ClientInstanceId,
-            RootPath = Path.GetTempFileName(),
+            RootPath = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N") + ".tmp"),
             InventoryPartType = FileSystemTypes.File,
             Name = "itests",
             InventoryCodeAndId = "itests"
@@ -123,7 +125,7 @@ public class R2DownloadResume_Tests
 
         // First upload a file so we can download it
         var inputContent = new string('z', 1_000_000);
-        var tempFile = Path.GetTempFileName();
+        var tempFile = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N") + ".tmp");
         await File.WriteAllTextAsync(tempFile, inputContent);
 
         var uploader = uploaderFactory.Build(tempFile, shared);

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2DownloadResume_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2DownloadResume_Tests.cs
@@ -60,6 +60,11 @@ public class R2DownloadResume_Tests : AbstractTester
     public void TearDown()
     {
         _clientScope.Dispose();
+
+        if (TestDirectory?.Exists == true)
+        {
+            TestDirectory.Delete(true);
+        }
     }
 
     [Test]

--- a/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2UploadDownload_Tests.cs
+++ b/tests/ByteSync.Client.IntegrationTests/Services/Communications/Transfers/R2UploadDownload_Tests.cs
@@ -4,6 +4,7 @@ using ByteSync.Business.Inventories;
 using ByteSync.Client.IntegrationTests.TestHelpers;
 using ByteSync.Common.Business.Inventories;
 using ByteSync.Common.Business.SharedFiles;
+using ByteSync.TestsCommon;
 using ByteSync.DependencyInjection;
 using ByteSync.Interfaces.Controls.Communications.Http;
 using ByteSync.Interfaces.Factories;
@@ -19,13 +20,14 @@ using ByteSync.Services.Communications.Transfers.Uploading;
 
 namespace ByteSync.Client.IntegrationTests.Services.Communications.Transfers;
 
-public class R2UploadDownload_Tests
+public class R2UploadDownload_Tests : AbstractTester
 {
     private ILifetimeScope _clientScope = null!;
 
     [SetUp]
     public void SetUp()
     {
+        CreateTestDirectory();
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         if (ByteSync.Services.ContainerProvider.Container == null)
         {
@@ -93,7 +95,7 @@ public class R2UploadDownload_Tests
             Source = new SharedDataPart
             {
                 ClientInstanceId = shared.ClientInstanceId,
-                RootPath = Path.GetTempPath(),
+                RootPath = TestDirectory.FullName,
                 InventoryPartType = FileSystemTypes.File,
                 Name = "itests",
                 InventoryCodeAndId = "itests"
@@ -107,7 +109,7 @@ public class R2UploadDownload_Tests
         sag.Targets.Add(new SharedDataPart
         {
             ClientInstanceId = shared.ClientInstanceId,
-            RootPath = Path.GetTempFileName(),
+            RootPath = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N") + ".tmp"),
             InventoryPartType = FileSystemTypes.File,
             Name = "itests",
             InventoryCodeAndId = "itests"
@@ -116,7 +118,7 @@ public class R2UploadDownload_Tests
         sharedActionsGroupRepository.SetSharedActionsGroups([sag]);
 
         var inputContent = new string('x', 1_000_000);
-        var tempFile = Path.GetTempFileName();
+        var tempFile = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N") + ".tmp");
         await File.WriteAllTextAsync(tempFile, inputContent);
 
         var uploader = uploaderFactory.Build(tempFile, shared);

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Downloading/SynchronizationDownloadFinalizerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Downloading/SynchronizationDownloadFinalizerTests.cs
@@ -8,11 +8,12 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using ByteSync.TestsCommon;
 
 namespace ByteSync.Client.UnitTests.Services.Communications.Transfers.Downloading;
 
 [TestFixture]
-public class SynchronizationDownloadFinalizerTests
+public class SynchronizationDownloadFinalizerTests : AbstractTester
 {
     private Mock<IDeltaManager> _deltaManager = null!;
     private Mock<ITemporaryFileManagerFactory> _temporaryFileManagerFactory = null!;
@@ -24,6 +25,7 @@ public class SynchronizationDownloadFinalizerTests
     [SetUp]
     public void Setup()
     {
+        CreateTestDirectory();
         _deltaManager = new Mock<IDeltaManager>(MockBehavior.Strict);
         _temporaryFileManagerFactory = new Mock<ITemporaryFileManagerFactory>(MockBehavior.Strict);
         _fileDatesSetter = new Mock<IFileDatesSetter>(MockBehavior.Strict);
@@ -276,15 +278,15 @@ public class SynchronizationDownloadFinalizerTests
         writer.Write(content);
     }
     
-    private static string GetTempFilePath()
+    private string GetTempFilePath()
     {
-        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var path = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N"));
         
         return path;
     }
     
-    private static string GetNewTempPath(string extension)
+    private string GetNewTempPath(string extension)
     {
-        return Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+        return Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N") + extension);
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Comparisons/InventoryComparerIncompletePartsFlatTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Comparisons/InventoryComparerIncompletePartsFlatTests.cs
@@ -8,28 +8,29 @@ using ByteSync.Models.FileSystems;
 using ByteSync.Models.Inventories;
 using ByteSync.Services.Comparisons;
 using FluentAssertions;
+using ByteSync.TestsCommon;
 using NUnit.Framework;
 
 namespace ByteSync.Client.UnitTests.Services.Comparisons;
 
 [TestFixture]
-public class InventoryComparerIncompletePartsFlatTests
+public class InventoryComparerIncompletePartsFlatTests : AbstractTester
 {
     private string _tempDirectory = null!;
     
     [SetUp]
     public void Setup()
     {
-        _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(_tempDirectory);
+        CreateTestDirectory();
+        _tempDirectory = TestDirectory.FullName;
     }
     
     [TearDown]
     public void TearDown()
     {
-        if (Directory.Exists(_tempDirectory))
+        if (TestDirectory?.Exists == true)
         {
-            Directory.Delete(_tempDirectory, true);
+            TestDirectory.Delete(true);
         }
     }
     

--- a/tests/ByteSync.Client.UnitTests/Services/Comparisons/InventoryComparerPropagateAccessIssuesTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Comparisons/InventoryComparerPropagateAccessIssuesTests.cs
@@ -7,32 +7,25 @@ using ByteSync.Common.Controls.Json;
 using ByteSync.Models.FileSystems;
 using ByteSync.Models.Inventories;
 using ByteSync.Services.Comparisons;
+using ByteSync.TestsCommon;
 using FluentAssertions;
 using NUnit.Framework;
 
 namespace ByteSync.Client.UnitTests.Services.Comparisons;
 
 [TestFixture]
-public class InventoryComparerPropagateAccessIssuesTests
+public class InventoryComparerPropagateAccessIssuesTests : AbstractTester
 {
     private string _tempDirectory = null!;
     
     [SetUp]
     public void Setup()
     {
-        _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(_tempDirectory);
+        CreateTestDirectory();
+        _tempDirectory = TestDirectory.FullName;
     }
     
-    [TearDown]
-    public void TearDown()
-    {
-        if (Directory.Exists(_tempDirectory))
-        {
-            Directory.Delete(_tempDirectory, true);
-        }
-    }
-    
+
     private static string CreateInventoryZipFile(string directory, Inventory inventory)
     {
         var zipPath = Path.Combine(directory, $"{Guid.NewGuid()}.zip");

--- a/tests/ByteSync.Client.UnitTests/Services/Comparisons/InventoryComparerPropagateAccessIssuesTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Comparisons/InventoryComparerPropagateAccessIssuesTests.cs
@@ -24,6 +24,15 @@ public class InventoryComparerPropagateAccessIssuesTests : AbstractTester
         CreateTestDirectory();
         _tempDirectory = TestDirectory.FullName;
     }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (TestDirectory?.Exists == true)
+        {
+            TestDirectory.Delete(true);
+        }
+    }
     
 
     private static string CreateInventoryZipFile(string directory, Inventory inventory)

--- a/tests/ByteSync.Client.UnitTests/Services/Configurations/LocalApplicationDataManagerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Configurations/LocalApplicationDataManagerTests.cs
@@ -8,17 +8,19 @@ using ByteSync.Services.Configurations;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using ByteSync.TestsCommon;
 
 namespace ByteSync.Client.UnitTests.Services.Configurations;
 
 [TestFixture]
-public class LocalApplicationDataManagerTests
+public class LocalApplicationDataManagerTests : AbstractTester
 {
     private Mock<IEnvironmentService> _environmentServiceMock = null!;
     
     [SetUp]
     public void SetUp()
     {
+        CreateTestDirectory();
         _environmentServiceMock = new Mock<IEnvironmentService>();
         _environmentServiceMock.SetupGet(e => e.ExecutionMode).Returns(ExecutionMode.Regular);
         _environmentServiceMock.SetupProperty(e => e.Arguments, []);
@@ -81,7 +83,7 @@ public class LocalApplicationDataManagerTests
     public void ApplicationDataPath_Should_Append_CustomSuffix_When_DebugArgumentProvided(OSPlatforms osPlatform)
     {
         // Arrange
-        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempRoot = TestDirectory.FullName;
         Directory.CreateDirectory(tempRoot);
         var assemblyDirectory = Directory.CreateDirectory(Path.Combine(tempRoot, "Portable")).FullName;
         var assemblyPath = Path.Combine(assemblyDirectory, "ByteSync.exe");
@@ -131,7 +133,7 @@ public class LocalApplicationDataManagerTests
     public void ApplicationDataPath_Should_Create_DebugDirectory_When_DebugModeWithoutOverride(OSPlatforms osPlatform)
     {
         // Arrange
-        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempRoot = TestDirectory.FullName;
         Directory.CreateDirectory(tempRoot);
         var assemblyDirectory = Directory.CreateDirectory(Path.Combine(tempRoot, "Portable")).FullName;
         var assemblyPath = Path.Combine(assemblyDirectory, "ByteSync.exe");
@@ -180,7 +182,7 @@ public class LocalApplicationDataManagerTests
     public void LogFilePath_Should_Return_MostRecent_Log_Excluding_Debug()
     {
         // Arrange
-        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempRoot = TestDirectory.FullName;
         Directory.CreateDirectory(tempRoot);
         var assemblyDirectory = Directory.CreateDirectory(Path.Combine(tempRoot, "Portable")).FullName;
         var assemblyPath = Path.Combine(assemblyDirectory, "ByteSync.exe");
@@ -243,7 +245,7 @@ public class LocalApplicationDataManagerTests
     public void DebugLogFilePath_Should_Return_MostRecent_Debug_Log()
     {
         // Arrange
-        var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempRoot = TestDirectory.FullName;
         Directory.CreateDirectory(tempRoot);
         var assemblyDirectory = Directory.CreateDirectory(Path.Combine(tempRoot, "Portable")).FullName;
         var assemblyPath = Path.Combine(assemblyDirectory, "ByteSync.exe");

--- a/tests/ByteSync.Client.UnitTests/Services/Inventories/FileSystemInspectorTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Inventories/FileSystemInspectorTests.cs
@@ -2,89 +2,84 @@ using ByteSync.Business.Inventories;
 using ByteSync.Common.Business.Misc;
 using ByteSync.Interfaces.Controls.Inventories;
 using ByteSync.Services.Inventories;
+using ByteSync.TestsCommon;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 
 namespace ByteSync.Client.UnitTests.Services.Inventories;
 
-public class FileSystemInspectorTests
+public class FileSystemInspectorTests : AbstractTester
 {
+    [SetUp]
+    public void SetUp()
+    {
+        CreateTestDirectory();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (TestDirectory?.Exists == true)
+        {
+            TestDirectory.Delete(true);
+        }
+    }
+
     [Test]
     public void ClassifyEntry_ReturnsDirectory_ForDirectoryInfo()
     {
         var posix = new Mock<IPosixFileTypeClassifier>(MockBehavior.Strict);
         posix.Setup(p => p.ClassifyPosixEntry(It.IsAny<string>())).Returns(FileSystemEntryKind.Unknown);
         var inspector = new FileSystemInspector(posix.Object);
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
-        
-        try
-        {
-            var result = inspector.ClassifyEntry(tempDirectory);
-            
-            result.Should().Be(FileSystemEntryKind.Directory);
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+        var tempDirectory = Directory.CreateDirectory(Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N")));
+
+        var result = inspector.ClassifyEntry(tempDirectory);
+
+        result.Should().Be(FileSystemEntryKind.Directory);
     }
-    
+
     [Test]
     public void ClassifyEntry_ReturnsRegularFile_ForFileInfo()
     {
         var posix = new Mock<IPosixFileTypeClassifier>(MockBehavior.Strict);
         posix.Setup(p => p.ClassifyPosixEntry(It.IsAny<string>())).Returns(FileSystemEntryKind.Unknown);
         var inspector = new FileSystemInspector(posix.Object);
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var tempDirectory = Directory.CreateDirectory(Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N")));
         var tempFilePath = Path.Combine(tempDirectory.FullName, "file.txt");
         File.WriteAllText(tempFilePath, "x");
         var fileInfo = new FileInfo(tempFilePath);
-        
-        try
-        {
-            var result = inspector.ClassifyEntry(fileInfo);
-            
-            result.Should().Be(FileSystemEntryKind.RegularFile);
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+
+        var result = inspector.ClassifyEntry(fileInfo);
+
+        result.Should().Be(FileSystemEntryKind.RegularFile);
     }
-    
+
     [Test]
     public void ClassifyEntry_ReturnsSymlink_WhenLinkTargetExists()
     {
         var posix = new Mock<IPosixFileTypeClassifier>(MockBehavior.Strict);
         posix.Setup(p => p.ClassifyPosixEntry(It.IsAny<string>())).Returns(FileSystemEntryKind.Unknown);
         var inspector = new FileSystemInspector(posix.Object);
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var tempDirectory = Directory.CreateDirectory(Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N")));
         var targetPath = Path.Combine(tempDirectory.FullName, "target.txt");
         File.WriteAllText(targetPath, "x");
         var linkPath = Path.Combine(tempDirectory.FullName, "link.txt");
-        
+
         try
         {
-            try
-            {
-                File.CreateSymbolicLink(linkPath, targetPath);
-            }
-            catch (Exception ex)
-            {
-                Assert.Ignore($"Symbolic link creation failed: {ex.GetType().Name}");
-            }
-            
-            var result = inspector.ClassifyEntry(new FileInfo(linkPath));
-            
-            result.Should().Be(FileSystemEntryKind.Symlink);
+            File.CreateSymbolicLink(linkPath, targetPath);
         }
-        finally
+        catch (Exception ex)
         {
-            Directory.Delete(tempDirectory.FullName, true);
+            Assert.Ignore($"Symbolic link creation failed: {ex.GetType().Name}");
         }
+
+        var result = inspector.ClassifyEntry(new FileInfo(linkPath));
+
+        result.Should().Be(FileSystemEntryKind.Symlink);
     }
-    
+
     [Test]
     [Platform(Include = "Linux,MacOsX")]
     public void ClassifyEntry_ReturnsPosixSpecialKind_WhenClassifierProvidesOne()
@@ -92,23 +87,16 @@ public class FileSystemInspectorTests
         var posix = new Mock<IPosixFileTypeClassifier>(MockBehavior.Strict);
         posix.Setup(p => p.ClassifyPosixEntry(It.IsAny<string>())).Returns(FileSystemEntryKind.Fifo);
         var inspector = new FileSystemInspector(posix.Object);
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var tempDirectory = Directory.CreateDirectory(Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N")));
         var tempFilePath = Path.Combine(tempDirectory.FullName, "file.txt");
         File.WriteAllText(tempFilePath, "x");
         var fileInfo = new FileInfo(tempFilePath);
-        
-        try
-        {
-            var result = inspector.ClassifyEntry(fileInfo);
-            
-            result.Should().Be(FileSystemEntryKind.Fifo);
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+
+        var result = inspector.ClassifyEntry(fileInfo);
+
+        result.Should().Be(FileSystemEntryKind.Fifo);
     }
-    
+
     [Test]
     [Platform(Include = "Linux,MacOsX")]
     public void ClassifyEntry_FallsBackToRegularFile_WhenPosixClassifierThrows()
@@ -116,100 +104,61 @@ public class FileSystemInspectorTests
         var posix = new Mock<IPosixFileTypeClassifier>(MockBehavior.Strict);
         posix.Setup(p => p.ClassifyPosixEntry(It.IsAny<string>())).Throws(new InvalidOperationException("boom"));
         var inspector = new FileSystemInspector(posix.Object);
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var tempDirectory = Directory.CreateDirectory(Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N")));
         var tempFilePath = Path.Combine(tempDirectory.FullName, "file.txt");
         File.WriteAllText(tempFilePath, "x");
         var fileInfo = new FileInfo(tempFilePath);
-        
-        try
-        {
-            var result = inspector.ClassifyEntry(fileInfo);
-            
-            result.Should().Be(FileSystemEntryKind.RegularFile);
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+
+        var result = inspector.ClassifyEntry(fileInfo);
+
+        result.Should().Be(FileSystemEntryKind.RegularFile);
     }
 
     [Test]
     public void IsNoiseDirectoryName_ShouldReturnTrue_ForKnownNoiseDirectory()
     {
         var inspector = new FileSystemInspector();
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
-        var noiseDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "$RECYCLE.BIN"));
+        var noiseDirectory = Directory.CreateDirectory(Path.Combine(TestDirectory.FullName, "$RECYCLE.BIN"));
 
-        try
-        {
-            var result = inspector.IsNoiseDirectoryName(noiseDirectory, OSPlatforms.Windows);
+        var result = inspector.IsNoiseDirectoryName(noiseDirectory, OSPlatforms.Windows);
 
-            result.Should().BeTrue();
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+        result.Should().BeTrue();
     }
 
     [Test]
     public void IsNoiseDirectoryName_ShouldReturnFalse_ForUnknownDirectory()
     {
         var inspector = new FileSystemInspector();
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
-        var regularDirectory = Directory.CreateDirectory(Path.Combine(tempDirectory.FullName, "regular"));
+        var regularDirectory = Directory.CreateDirectory(Path.Combine(TestDirectory.FullName, "regular"));
 
-        try
-        {
-            var result = inspector.IsNoiseDirectoryName(regularDirectory, OSPlatforms.Windows);
+        var result = inspector.IsNoiseDirectoryName(regularDirectory, OSPlatforms.Windows);
 
-            result.Should().BeFalse();
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+        result.Should().BeFalse();
     }
 
     [Test]
     public void IsNoiseFileName_ShouldReturnTrue_ForKnownNoiseFile()
     {
         var inspector = new FileSystemInspector();
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
-        var filePath = Path.Combine(tempDirectory.FullName, "thumbs.db");
+        var filePath = Path.Combine(TestDirectory.FullName, "thumbs.db");
         File.WriteAllText(filePath, "x");
         var fileInfo = new FileInfo(filePath);
 
-        try
-        {
-            var result = inspector.IsNoiseFileName(fileInfo, OSPlatforms.Windows);
+        var result = inspector.IsNoiseFileName(fileInfo, OSPlatforms.Windows);
 
-            result.Should().BeTrue();
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+        result.Should().BeTrue();
     }
 
     [Test]
     public void IsNoiseFileName_ShouldReturnFalse_ForUnknownFile()
     {
         var inspector = new FileSystemInspector();
-        var tempDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
-        var filePath = Path.Combine(tempDirectory.FullName, "regular.txt");
+        var filePath = Path.Combine(TestDirectory.FullName, "regular.txt");
         File.WriteAllText(filePath, "x");
         var fileInfo = new FileInfo(filePath);
 
-        try
-        {
-            var result = inspector.IsNoiseFileName(fileInfo, OSPlatforms.Windows);
+        var result = inspector.IsNoiseFileName(fileInfo, OSPlatforms.Windows);
 
-            result.Should().BeFalse();
-        }
-        finally
-        {
-            Directory.Delete(tempDirectory.FullName, true);
-        }
+        result.Should().BeFalse();
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Inventories/InventoryLoaderIncompleteFlagTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Inventories/InventoryLoaderIncompleteFlagTests.cs
@@ -7,28 +7,29 @@ using ByteSync.Models.FileSystems;
 using ByteSync.Models.Inventories;
 using ByteSync.Services.Inventories;
 using FluentAssertions;
+using ByteSync.TestsCommon;
 using NUnit.Framework;
 
 namespace ByteSync.Client.UnitTests.Services.Inventories;
 
 [TestFixture]
-public class InventoryLoaderIncompleteFlagTests
+public class InventoryLoaderIncompleteFlagTests : AbstractTester
 {
     private string _tempDirectory = null!;
     
     [SetUp]
     public void Setup()
     {
-        _tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(_tempDirectory);
+        CreateTestDirectory();
+        _tempDirectory = TestDirectory.FullName;
     }
     
     [TearDown]
     public void TearDown()
     {
-        if (Directory.Exists(_tempDirectory))
+        if (TestDirectory?.Exists == true)
         {
-            Directory.Delete(_tempDirectory, true);
+            TestDirectory.Delete(true);
         }
     }
     

--- a/tests/ByteSync.Client.UnitTests/Services/Inventories/PosixFileTypeClassifierTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Inventories/PosixFileTypeClassifierTests.cs
@@ -1,13 +1,29 @@
 using System.IO;
 using ByteSync.Business.Inventories;
 using ByteSync.Services.Inventories;
+using ByteSync.TestsCommon;
 using FluentAssertions;
 using NUnit.Framework;
 
 namespace ByteSync.Client.UnitTests.Services.Inventories;
 
-public class PosixFileTypeClassifierTests
+public class PosixFileTypeClassifierTests : AbstractTester
 {
+    [SetUp]
+    public void SetUp()
+    {
+        CreateTestDirectory();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (TestDirectory?.Exists == true)
+        {
+            TestDirectory.Delete(true);
+        }
+    }
+
     [Test]
     [Platform(Include = "Linux,MacOsX")]
     [TestCase("/dev/null", FileSystemEntryKind.CharacterDevice)]
@@ -36,26 +52,19 @@ public class PosixFileTypeClassifierTests
     public void ClassifyPosixEntry_ReturnsRegularFile_ForTempFile()
     {
         var classifier = new PosixFileTypeClassifier();
-        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempDirectory = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDirectory);
         var tempFile = Path.Combine(tempDirectory, "file.txt");
         File.WriteAllText(tempFile, "data");
 
-        try
-        {
-            var result = classifier.ClassifyPosixEntry(tempFile);
+        var result = classifier.ClassifyPosixEntry(tempFile);
 
-            if (result == FileSystemEntryKind.Unknown)
-            {
-                Assert.Ignore($"POSIX classification returned Unknown for '{tempFile}'.");
-            }
-
-            result.Should().Be(FileSystemEntryKind.RegularFile);
-        }
-        finally
+        if (result == FileSystemEntryKind.Unknown)
         {
-            Directory.Delete(tempDirectory, true);
+            Assert.Ignore($"POSIX classification returned Unknown for '{tempFile}'.");
         }
+
+        result.Should().Be(FileSystemEntryKind.RegularFile);
     }
 
     [Test]
@@ -63,24 +72,17 @@ public class PosixFileTypeClassifierTests
     public void ClassifyPosixEntry_ReturnsDirectory_ForTempDirectory()
     {
         var classifier = new PosixFileTypeClassifier();
-        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempDirectory = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDirectory);
 
-        try
-        {
-            var result = classifier.ClassifyPosixEntry(tempDirectory);
+        var result = classifier.ClassifyPosixEntry(tempDirectory);
 
-            if (result == FileSystemEntryKind.Unknown)
-            {
-                Assert.Ignore($"POSIX classification returned Unknown for '{tempDirectory}'.");
-            }
-
-            result.Should().Be(FileSystemEntryKind.Directory);
-        }
-        finally
+        if (result == FileSystemEntryKind.Unknown)
         {
-            Directory.Delete(tempDirectory, true);
+            Assert.Ignore($"POSIX classification returned Unknown for '{tempDirectory}'.");
         }
+
+        result.Should().Be(FileSystemEntryKind.Directory);
     }
 
     [Test]
@@ -88,7 +90,7 @@ public class PosixFileTypeClassifierTests
     public void ClassifyPosixEntry_ReturnsUnknown_ForMissingPath()
     {
         var classifier = new PosixFileTypeClassifier();
-        var missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "missing");
+        var missingPath = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N"), "missing");
 
         var result = classifier.ClassifyPosixEntry(missingPath);
 
@@ -100,7 +102,7 @@ public class PosixFileTypeClassifierTests
     public void ClassifyPosixEntry_ReturnsSymlink_WhenSupported()
     {
         var classifier = new PosixFileTypeClassifier();
-        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempDirectory = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDirectory);
         var targetFile = Path.Combine(tempDirectory, "target.txt");
         File.WriteAllText(targetFile, "data");
@@ -108,28 +110,21 @@ public class PosixFileTypeClassifierTests
 
         try
         {
-            try
-            {
-                File.CreateSymbolicLink(linkPath, targetFile);
-            }
-            catch (Exception ex)
-            {
-                Assert.Ignore($"Symbolic link creation failed: {ex.GetType().Name}");
-            }
-
-            var result = classifier.ClassifyPosixEntry(linkPath);
-
-            if (result == FileSystemEntryKind.Unknown)
-            {
-                Assert.Ignore($"POSIX classification returned Unknown for '{linkPath}'.");
-            }
-
-            result.Should().Be(FileSystemEntryKind.Symlink);
+            File.CreateSymbolicLink(linkPath, targetFile);
         }
-        finally
+        catch (Exception ex)
         {
-            Directory.Delete(tempDirectory, true);
+            Assert.Ignore($"Symbolic link creation failed: {ex.GetType().Name}");
         }
+
+        var result = classifier.ClassifyPosixEntry(linkPath);
+
+        if (result == FileSystemEntryKind.Unknown)
+        {
+            Assert.Ignore($"POSIX classification returned Unknown for '{linkPath}'.");
+        }
+
+        result.Should().Be(FileSystemEntryKind.Symlink);
     }
 
     [Test]
@@ -137,26 +132,19 @@ public class PosixFileTypeClassifierTests
     public void ClassifyPosixEntry_ReturnsUnknown_WhenUnixFileInfoThrows()
     {
         var classifier = new PosixFileTypeClassifier(_ => throw new InvalidOperationException("fail"));
-        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempDirectory = Path.Combine(TestDirectory.FullName, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDirectory);
         var tempFile = Path.Combine(tempDirectory, "file.txt");
         File.WriteAllText(tempFile, "data");
 
-        try
-        {
-            var result = classifier.ClassifyPosixEntry(tempFile);
+        var result = classifier.ClassifyPosixEntry(tempFile);
 
-            if (result == FileSystemEntryKind.Unknown)
-            {
-                Assert.Ignore($"POSIX classification returned Unknown for '{tempFile}'.");
-            }
-            
-            result.Should().Be(FileSystemEntryKind.RegularFile);
-        }
-        finally
+        if (result == FileSystemEntryKind.Unknown)
         {
-            Directory.Delete(tempDirectory, true);
+            Assert.Ignore($"POSIX classification returned Unknown for '{tempFile}'.");
         }
+
+        result.Should().Be(FileSystemEntryKind.RegularFile);
     }
 
     [Test]

--- a/tests/ByteSync.Client.UnitTests/ViewModels/Sessions/DataNodes/DataNodeSourcesViewModelTests.cs
+++ b/tests/ByteSync.Client.UnitTests/ViewModels/Sessions/DataNodes/DataNodeSourcesViewModelTests.cs
@@ -12,11 +12,12 @@ using DynamicData;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using ByteSync.TestsCommon;
 
 namespace ByteSync.Client.UnitTests.ViewModels.Sessions.DataNodes;
 
 [TestFixture]
-public class DataNodeSourcesViewModelTests
+public class DataNodeSourcesViewModelTests : AbstractTester
 {
     private Mock<ISessionService> _sessionServiceMock = null!;
     private Mock<IDataSourceService> _dataSourceServiceMock = null!;
@@ -29,6 +30,7 @@ public class DataNodeSourcesViewModelTests
     [SetUp]
     public void SetUp()
     {
+        CreateTestDirectory();
         _dataNode = new DataNode { Id = "DN_1" };
         _sessionServiceMock = new Mock<ISessionService>();
         _dataSourceServiceMock = new Mock<IDataSourceService>();
@@ -58,7 +60,7 @@ public class DataNodeSourcesViewModelTests
     public async Task AddDirectoryCommand_WhenUserSelectsDirectory_ShouldCallCreateAndTryAddDataSource()
     {
         // Arrange
-        var selectedPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+        var selectedPath = TestDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar);
         _fileDialogServiceMock
             .Setup(f => f.ShowOpenFolderDialogAsync(It.IsAny<string>()))
             .ReturnsAsync(selectedPath);


### PR DESCRIPTION
Refactored unit and integration test classes to inherit from AbstractTester
and use its TestDirectory property instead of the system temp directory.
This ensures automatic cleanup of temporary files and removes dependency
on the system's temporary directory.
Affected classes:
- InventoryComparerPropagateAccessIssuesTests
- LocalApplicationDataManagerTests
- SynchronizationDownloadFinalizerTests
- DataNodeSourcesViewModelTests
- R2UploadDownload_Tests
- R2DownloadResume_Tests