### PR TITLE
[fix] Enable adaptive downscale after client timeouts

### DIFF
--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
@@ -14,6 +14,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     private const int MAX_CHUNK_SIZE_BYTES = 16 * 1024 * 1024; // 16 MB
     private const int MIN_PARALLELISM = 2;
     private const int MAX_PARALLELISM = 4;
+    private const int CLIENT_TIMEOUTS_BEFORE_DOWNSCALE = 2;
     
     private const double MULTIPLIER_2_X = 2.0;
     private const double MULTIPLIER_1_75_X = 1.75;
@@ -36,6 +37,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     private readonly Queue<long> _recentBytes;
     private int _successesInWindow;
     private int _windowSize;
+    private int _consecutiveClientTimeouts;
     private readonly ILogger<AdaptiveUploadController> _logger;
     private readonly object _syncRoot = new();
     
@@ -86,10 +88,18 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     {
         lock (_syncRoot)
         {
-            if (IsClientSideFailure(uploadResult.FailureKind))
+            if (uploadResult.FailureKind == UploadFailureKind.ClientCancellation)
             {
                 return;
             }
+            
+            if (uploadResult.FailureKind == UploadFailureKind.ClientTimeout)
+            {
+                HandleClientTimeout(uploadResult.FileId);
+                return;
+            }
+            
+            _consecutiveClientTimeouts = 0;
             
             EnqueueSample(uploadResult.Elapsed, uploadResult.IsSuccess, uploadResult.ActualBytes);
             
@@ -151,9 +161,26 @@ public class AdaptiveUploadController : IAdaptiveUploadController
         }
     }
     
-    private static bool IsClientSideFailure(UploadFailureKind failureKind)
+    private void HandleClientTimeout(string? fileId)
     {
-        return failureKind is UploadFailureKind.ClientCancellation or UploadFailureKind.ClientTimeout;
+        _consecutiveClientTimeouts += 1;
+        if (_consecutiveClientTimeouts < CLIENT_TIMEOUTS_BEFORE_DOWNSCALE)
+        {
+            _logger.LogDebug(
+                "Adaptive: file {FileId} client timeout {TimeoutCount}/{Threshold}. Waiting before downscale",
+                fileId ?? "-",
+                _consecutiveClientTimeouts,
+                CLIENT_TIMEOUTS_BEFORE_DOWNSCALE);
+            
+            return;
+        }
+        
+        _logger.LogInformation(
+            "Adaptive: file {FileId} client timeout threshold reached ({TimeoutCount}). Downscaling upload settings",
+            fileId ?? "-",
+            _consecutiveClientTimeouts);
+        _consecutiveClientTimeouts = 0;
+        Downscale(fileId, "client timeouts");
     }
     
     private bool HandleBandwidthReset(bool isSuccess, int? statusCode)
@@ -192,38 +219,43 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     {
         if (maxElapsed > _downscaleThreshold)
         {
-            if (_currentParallelism > MIN_PARALLELISM)
-            {
-                _logger.LogInformation(
-                    "Adaptive: file {FileId} Downscale. Reducing parallelism {Prev} -> {Next}. Resetting window (window before {WindowBefore})",
-                    fileId ?? "-",
-                    _currentParallelism, _currentParallelism - 1,
-                    _windowSize);
-                _currentParallelism -= 1;
-                _windowSize = _currentParallelism;
-                ResetWindow();
-                
-                return true;
-            }
-            
-            var reduced = (int)Math.Max(MIN_CHUNK_SIZE_BYTES, _currentChunkSizeBytes * 0.75);
-            if (reduced != _currentChunkSizeBytes)
-            {
-                _currentChunkSizeBytes = reduced;
-                _logger.LogInformation(
-                    "Adaptive: file {FileId} Downscale. maxElapsed={MaxElapsedMs} ms > {ThresholdMs} ms. New chunkSize={ChunkKb} KB",
-                    fileId ?? "-",
-                    maxElapsed.TotalMilliseconds,
-                    _downscaleThreshold.TotalMilliseconds,
-                    Math.Round(_currentChunkSizeBytes / 1024d));
-            }
-            
-            ResetWindow();
-            
+            Downscale(fileId, $"maxElapsed={maxElapsed.TotalMilliseconds} ms > {_downscaleThreshold.TotalMilliseconds} ms");
             return true;
         }
         
         return false;
+    }
+    
+    private void Downscale(string? fileId, string reason)
+    {
+        if (_currentParallelism > MIN_PARALLELISM)
+        {
+            _logger.LogInformation(
+                "Adaptive: file {FileId} Downscale ({Reason}). Reducing parallelism {Prev} -> {Next}. Resetting window (window before {WindowBefore})",
+                fileId ?? "-",
+                reason,
+                _currentParallelism,
+                _currentParallelism - 1,
+                _windowSize);
+            _currentParallelism -= 1;
+            _windowSize = _currentParallelism;
+            ResetWindow();
+            
+            return;
+        }
+        
+        var reduced = (int)Math.Max(MIN_CHUNK_SIZE_BYTES, _currentChunkSizeBytes * 0.75);
+        if (reduced != _currentChunkSizeBytes)
+        {
+            _currentChunkSizeBytes = reduced;
+            _logger.LogInformation(
+                "Adaptive: file {FileId} Downscale ({Reason}). New chunkSize={ChunkKb} KB",
+                fileId ?? "-",
+                reason,
+                Math.Round(_currentChunkSizeBytes / 1024d));
+        }
+        
+        ResetWindow();
     }
     
     private void TryHandleUpscale(string? fileId)
@@ -362,6 +394,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
             _currentChunkSizeBytes = Math.Clamp(INITIAL_CHUNK_SIZE_BYTES, MIN_CHUNK_SIZE_BYTES, MAX_CHUNK_SIZE_BYTES);
             _currentParallelism = MIN_PARALLELISM;
             _windowSize = _currentParallelism;
+            _consecutiveClientTimeouts = 0;
         }
         
         ResetWindow();

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
@@ -90,6 +90,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
         {
             if (uploadResult.FailureKind == UploadFailureKind.ClientCancellation)
             {
+                _consecutiveClientTimeouts = 0;
                 return;
             }
             

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
@@ -93,6 +93,7 @@ public class AdaptiveUploadControllerTests
             FeedFastWindow(_controller);
         }
         
+        _controller.CurrentChunkSizeBytes.Should().BeGreaterThanOrEqualTo(4 * 1024 * 1024);
         _controller.CurrentParallelism.Should().BeGreaterThan(2);
         var beforeParallelism = _controller.CurrentParallelism;
         var beforeChunk = _controller.CurrentChunkSizeBytes;

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
@@ -184,40 +184,58 @@ public class AdaptiveUploadControllerTests
     }
     
     [Test]
-    public void ClientTimeout_DoesNotEnterAdaptiveWindow_AndDoesNotResetChunkSize()
+    public void ClientTimeouts_DownscaleBelowInitialChunkSize_WhenAtMinParallelism()
     {
-        // Arrange - Inflate chunk and make sure parallelism is just at min (=2)
-        var safety = 10;
-        while (_controller.CurrentChunkSizeBytes < 1024 * 1024 && safety-- > 0)
+        // Arrange
+        _controller.CurrentParallelism.Should().Be(2);
+        _controller.CurrentChunkSizeBytes.Should().Be(500 * 1024);
+        
+        // Act - Two consecutive client-side timeouts trigger controlled downscale
+        FeedClientTimeouts(_controller, 2);
+        
+        // Assert
+        _controller.CurrentParallelism.Should().Be(2);
+        _controller.CurrentChunkSizeBytes.Should().BeLessThan(500 * 1024);
+        _controller.CurrentChunkSizeBytes.Should().Be(375 * 1024);
+    }
+    
+    [Test]
+    public void ClientTimeouts_ReduceParallelismFirst_WhenAboveMinParallelism()
+    {
+        // Arrange
+        var safety = 100;
+        while (_controller.CurrentChunkSizeBytes < 4 * 1024 * 1024 && safety-- > 0)
         {
             FeedFastWindow(_controller);
         }
-        _controller.CurrentParallelism.Should().Be(2);
-        var inflatedChunk = _controller.CurrentChunkSizeBytes;
         
-        // Act - Feed a window of slow client-timeout failures (with the new failure kind)
-        var p = _controller.CurrentParallelism;
-        for (var i = 0; i < p; i++)
+        _controller.CurrentParallelism.Should().BeGreaterThan(2);
+        var beforeParallelism = _controller.CurrentParallelism;
+        var beforeChunk = _controller.CurrentChunkSizeBytes;
+        
+        // Act
+        FeedClientTimeouts(_controller, 2);
+        
+        // Assert
+        _controller.CurrentParallelism.Should().Be(beforeParallelism - 1);
+        _controller.CurrentChunkSizeBytes.Should().Be(beforeChunk);
+    }
+    
+    [Test]
+    public void ClientTimeouts_DoNotReduceChunkSizeBelowMinimum()
+    {
+        // Arrange
+        _controller.CurrentParallelism.Should().Be(2);
+        
+        // Act
+        for (var i = 0; i < 20; i++)
         {
-            RecordUploadResult(
-                _controller,
-                TimeSpan.FromSeconds(60),
-                isSuccess: false,
-                partNumber: i + 1,
-                statusCode: 0,
-                failureKind: UploadFailureKind.ClientTimeout);
+            FeedClientTimeouts(_controller, 2);
         }
         
-        RecordUploadResult(
-            _controller,
-            TimeSpan.FromSeconds(1),
-            isSuccess: true,
-            partNumber: 100);
-        
-        // Assert - the timeout samples were ignored and cannot trigger a later downscale
-        _controller.CurrentChunkSizeBytes.Should().NotBe(500 * 1024);
-        _controller.CurrentChunkSizeBytes.Should().Be(inflatedChunk,
-            because: "client-side cancellations are not bandwidth signals and must not influence chunk sizing");
+        // Assert
+        _controller.CurrentChunkSizeBytes.Should().Be(64 * 1024);
+        _controller.CurrentParallelism.Should().Be(2);
     }
     
     [Test]
@@ -245,6 +263,20 @@ public class AdaptiveUploadControllerTests
         for (var i = 0; i < p; i++)
         {
             RecordUploadResult(controller, elapsed, isSuccess: successes, partNumber: i + 1);
+        }
+    }
+    
+    private static void FeedClientTimeouts(AdaptiveUploadController controller, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            RecordUploadResult(
+                controller,
+                TimeSpan.FromSeconds(60),
+                isSuccess: false,
+                partNumber: i + 1,
+                statusCode: 0,
+                failureKind: UploadFailureKind.ClientTimeout);
         }
     }
     


### PR DESCRIPTION
## Summary
- Downscale upload settings after consecutive client-side upload timeouts.
- Reduce parallelism before chunk size, then allow chunk size to go below 500 KB down to the 64 KB floor.
- Add unit coverage for timeout-driven downscale and minimum chunk size behavior.

## Test plan
- dotnet test tests/ByteSync.Client.UnitTests/ByteSync.Client.UnitTests.csproj --filter AdaptiveUploadControllerTests
- dotnet test tests/ByteSync.Client.UnitTests/ByteSync.Client.UnitTests.csproj
- dotnet test tests/ByteSync.Client.IntegrationTests/ByteSync.Client.IntegrationTests.csproj