### PR TITLE
[fix] Improve upload retry resilience

### DIFF
--- a/src/ByteSync.Client/Services/Communications/Transfers/Strategies/AzureBlobStorageUploadStrategy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Strategies/AzureBlobStorageUploadStrategy.cs
@@ -21,7 +21,7 @@ public class AzureBlobStorageUploadStrategy : IUploadStrategy
         try
         {
             var options = new BlobClientOptions();
-            options.Retry.NetworkTimeout = TimeSpan.FromMinutes(1);
+            options.Retry.NetworkTimeout = TimeSpan.FromMinutes(10);
 
             slice.MemoryStream.Position = 0;
             var blob = new BlobClient(new Uri(storageLocation.Url), options);

--- a/src/ByteSync.Client/Services/Communications/Transfers/Strategies/CloudflareR2UploadStrategy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Strategies/CloudflareR2UploadStrategy.cs
@@ -29,7 +29,7 @@ public class CloudflareR2UploadStrategy : IUploadStrategy
             slice.MemoryStream.Position = 0;
             
             using var httpClient = _httpClientFactory.CreateClient();
-            httpClient.Timeout = TimeSpan.FromMinutes(1);
+            httpClient.Timeout = Timeout.InfiniteTimeSpan;
             httpClient.DefaultRequestHeaders.ExpectContinue = false;
             
             // Build ReadOnlyMemory without copying when possible; fallback to ToArray otherwise

--- a/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
@@ -31,7 +31,7 @@ public static class UploadFailureClassifier
 
     private static bool IsClientNetworkError(Exception exception)
     {
-        if (exception is not HttpRequestException and not IOException)
+        if (exception is not HttpRequestException and not IOException and not SocketException)
         {
             return false;
         }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
@@ -1,4 +1,7 @@
 using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using ByteSync.Common.Business.Communications.Transfers;
 
@@ -12,12 +15,44 @@ public static class UploadFailureClassifier
         {
             return UploadFileResponse.ClientCancellation(exception);
         }
-        
+
         if (exception is OperationCanceledException)
         {
             return UploadFileResponse.ClientTimeout(exception);
         }
 
+        if (IsClientNetworkError(exception))
+        {
+            return UploadFileResponse.ClientNetworkError(exception);
+        }
+
         return UploadFileResponse.Failure(500, exception);
+    }
+
+    private static bool IsClientNetworkError(Exception exception)
+    {
+        if (exception is not HttpRequestException and not IOException)
+        {
+            return false;
+        }
+
+        var current = exception;
+        while (current != null)
+        {
+            if (current is SocketException socketException)
+            {
+                return socketException.SocketErrorCode is SocketError.ConnectionReset
+                    or SocketError.ConnectionAborted
+                    or SocketError.TimedOut
+                    or SocketError.NetworkDown
+                    or SocketError.NetworkUnreachable
+                    or SocketError.HostDown
+                    or SocketError.HostUnreachable;
+            }
+
+            current = current.InnerException;
+        }
+
+        return false;
     }
 }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
@@ -94,9 +94,9 @@ public class AdaptiveUploadController : IAdaptiveUploadController
                 return;
             }
             
-            if (uploadResult.FailureKind == UploadFailureKind.ClientTimeout)
+            if (uploadResult.FailureKind is UploadFailureKind.ClientTimeout or UploadFailureKind.ClientNetworkError)
             {
-                HandleClientTimeout(uploadResult.FileId);
+                HandleClientNetworkIssue(uploadResult.FileId, uploadResult.FailureKind);
                 return;
             }
             
@@ -162,14 +162,15 @@ public class AdaptiveUploadController : IAdaptiveUploadController
         }
     }
     
-    private void HandleClientTimeout(string? fileId)
+    private void HandleClientNetworkIssue(string? fileId, UploadFailureKind failureKind)
     {
         _consecutiveClientTimeouts += 1;
         if (_consecutiveClientTimeouts < CLIENT_TIMEOUTS_BEFORE_DOWNSCALE)
         {
             _logger.LogDebug(
-                "Adaptive: file {FileId} client timeout {TimeoutCount}/{Threshold}. Waiting before downscale",
+                "Adaptive: file {FileId} client network issue {FailureKind} {TimeoutCount}/{Threshold}. Waiting before downscale",
                 fileId ?? "-",
+                failureKind,
                 _consecutiveClientTimeouts,
                 CLIENT_TIMEOUTS_BEFORE_DOWNSCALE);
             
@@ -177,11 +178,11 @@ public class AdaptiveUploadController : IAdaptiveUploadController
         }
         
         _logger.LogInformation(
-            "Adaptive: file {FileId} client timeout threshold reached ({TimeoutCount}). Downscaling upload settings",
+            "Adaptive: file {FileId} client network issue threshold reached ({TimeoutCount}). Downscaling upload settings",
             fileId ?? "-",
             _consecutiveClientTimeouts);
         _consecutiveClientTimeouts = 0;
-        Downscale(fileId, "client timeouts");
+        Downscale(fileId, "client network issues");
     }
     
     private bool HandleBandwidthReset(bool isSuccess, int? statusCode)

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
@@ -14,7 +14,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     private const int MAX_CHUNK_SIZE_BYTES = 16 * 1024 * 1024; // 16 MB
     private const int MIN_PARALLELISM = 2;
     private const int MAX_PARALLELISM = 4;
-    private const int CLIENT_TIMEOUTS_BEFORE_DOWNSCALE = 2;
+    private const int CLIENT_NETWORK_ISSUES_BEFORE_DOWNSCALE = 2;
     
     private const double MULTIPLIER_2_X = 2.0;
     private const double MULTIPLIER_1_75_X = 1.75;
@@ -37,7 +37,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     private readonly Queue<long> _recentBytes;
     private int _successesInWindow;
     private int _windowSize;
-    private int _consecutiveClientTimeouts;
+    private int _consecutiveClientNetworkIssues;
     private readonly ILogger<AdaptiveUploadController> _logger;
     private readonly object _syncRoot = new();
     
@@ -90,7 +90,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
         {
             if (uploadResult.FailureKind == UploadFailureKind.ClientCancellation)
             {
-                _consecutiveClientTimeouts = 0;
+                _consecutiveClientNetworkIssues = 0;
                 return;
             }
             
@@ -100,7 +100,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
                 return;
             }
             
-            _consecutiveClientTimeouts = 0;
+            _consecutiveClientNetworkIssues = 0;
             
             EnqueueSample(uploadResult.Elapsed, uploadResult.IsSuccess, uploadResult.ActualBytes);
             
@@ -164,24 +164,24 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     
     private void HandleClientNetworkIssue(string? fileId, UploadFailureKind failureKind)
     {
-        _consecutiveClientTimeouts += 1;
-        if (_consecutiveClientTimeouts < CLIENT_TIMEOUTS_BEFORE_DOWNSCALE)
+        _consecutiveClientNetworkIssues += 1;
+        if (_consecutiveClientNetworkIssues < CLIENT_NETWORK_ISSUES_BEFORE_DOWNSCALE)
         {
             _logger.LogDebug(
-                "Adaptive: file {FileId} client network issue {FailureKind} {TimeoutCount}/{Threshold}. Waiting before downscale",
+                "Adaptive: file {FileId} client network issue {FailureKind} {IssueCount}/{Threshold}. Waiting before downscale",
                 fileId ?? "-",
                 failureKind,
-                _consecutiveClientTimeouts,
-                CLIENT_TIMEOUTS_BEFORE_DOWNSCALE);
+                _consecutiveClientNetworkIssues,
+                CLIENT_NETWORK_ISSUES_BEFORE_DOWNSCALE);
             
             return;
         }
         
         _logger.LogInformation(
-            "Adaptive: file {FileId} client network issue threshold reached ({TimeoutCount}). Downscaling upload settings",
+            "Adaptive: file {FileId} client network issue threshold reached ({IssueCount}). Downscaling upload settings",
             fileId ?? "-",
-            _consecutiveClientTimeouts);
-        _consecutiveClientTimeouts = 0;
+            _consecutiveClientNetworkIssues);
+        _consecutiveClientNetworkIssues = 0;
         Downscale(fileId, "client network issues");
     }
     
@@ -396,7 +396,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
             _currentChunkSizeBytes = Math.Clamp(INITIAL_CHUNK_SIZE_BYTES, MIN_CHUNK_SIZE_BYTES, MAX_CHUNK_SIZE_BYTES);
             _currentParallelism = MIN_PARALLELISM;
             _windowSize = _currentParallelism;
-            _consecutiveClientTimeouts = 0;
+            _consecutiveClientNetworkIssues = 0;
         }
         
         ResetWindow();

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
@@ -63,7 +63,10 @@ public class FileSlicer : IFileSlicer
                         _semaphoreSlim.Release();
                     }
 
-                    await _availableSlices.Writer.WriteAsync(fileUploaderSlice);
+                    if (!await TryWriteSliceAsync(fileUploaderSlice))
+                    {
+                        return;
+                    }
                 }
                 else
                 {
@@ -126,7 +129,10 @@ public class FileSlicer : IFileSlicer
                         _semaphoreSlim.Release();
                     }
 
-                    await _availableSlices.Writer.WriteAsync(fileUploaderSlice);
+                    if (!await TryWriteSliceAsync(fileUploaderSlice))
+                    {
+                        return;
+                    }
                 }
                 else
                 {
@@ -150,6 +156,22 @@ public class FileSlicer : IFileSlicer
             }
             _exceptionOccurred.Set();
             _availableSlices.Writer.TryComplete(ex);
+        }
+    }
+
+    private async Task<bool> TryWriteSliceAsync(FileUploaderSlice fileUploaderSlice)
+    {
+        try
+        {
+            await _availableSlices.Writer.WriteAsync(fileUploaderSlice);
+
+            return true;
+        }
+        catch (ChannelClosedException) when (_exceptionOccurred.WaitOne(0))
+        {
+            fileUploaderSlice.MemoryStream.Dispose();
+
+            return false;
         }
     }
 }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileSlicer.cs
@@ -169,7 +169,7 @@ public class FileSlicer : IFileSlicer
         }
         catch (ChannelClosedException) when (_exceptionOccurred.WaitOne(0))
         {
-            fileUploaderSlice.MemoryStream.Dispose();
+            await fileUploaderSlice.MemoryStream.DisposeAsync();
 
             return false;
         }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadCoordinator.cs
@@ -12,7 +12,7 @@ public class FileUploadCoordinator : IFileUploadCoordinator
     private readonly ManualResetEvent _uploadingIsFinished;
     private readonly ManualResetEvent _exceptionOccurred;
     private readonly ILogger<FileUploadCoordinator> _logger;
-    private const int CHANNEL_CAPACITY = 8;
+    private const int CHANNEL_CAPACITY = 2;
 
     public FileUploadCoordinator(ILogger<FileUploadCoordinator> logger)
     {

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
@@ -28,6 +28,7 @@ public class FileUploadWorker : IFileUploadWorker
     private CancellationTokenSource CancellationTokenSource { get; }
     
     private static int _workerTaskCounter;
+    private int _remainingSlicesDrained;
     
     public FileUploadWorker(
         IPolicyFactory policyFactory,
@@ -145,7 +146,7 @@ public class FileUploadWorker : IFileUploadWorker
                 }
                 catch (Exception ex)
                 {
-                    await HandleUploadExceptionAsync(progressState, ex, workerId);
+                    await HandleUploadExceptionAsync(progressState, availableSlices, ex, workerId);
 
                     return;
                 }
@@ -385,7 +386,7 @@ public class FileUploadWorker : IFileUploadWorker
     {
         if (response == null || !response.IsSuccess)
         {
-            throw new Exception(
+            throw new InvalidOperationException(
                 $"UploadAvailableSlice: upload attempt failed. Status: {response?.StatusCode}, Error: {response?.ErrorMessage}");
         }
     }
@@ -410,7 +411,11 @@ public class FileUploadWorker : IFileUploadWorker
         }
     }
     
-    private async Task HandleUploadExceptionAsync(UploadProgressState progressState, Exception ex, int workerId)
+    private async Task HandleUploadExceptionAsync(
+        UploadProgressState progressState,
+        Channel<FileUploaderSlice> availableSlices,
+        Exception ex,
+        int workerId)
     {
         _logger.LogError(ex, "UploadAvailableSlice: worker {WorkerId} error", workerId);
         
@@ -425,7 +430,22 @@ public class FileUploadWorker : IFileUploadWorker
         }
         
         _exceptionOccurred.Set();
+        availableSlices.Writer.TryComplete(ex);
         await CancellationTokenSource.CancelAsync();
+        DrainRemainingSlices(availableSlices.Reader);
+    }
+
+    private void DrainRemainingSlices(ChannelReader<FileUploaderSlice> reader)
+    {
+        if (Interlocked.Exchange(ref _remainingSlicesDrained, 1) == 1)
+        {
+            return;
+        }
+
+        while (reader.TryRead(out var slice))
+        {
+            DisposeSlice(slice);
+        }
     }
     
     private void DisposeSlice(FileUploaderSlice slice)
@@ -489,7 +509,7 @@ public class FileUploadWorker : IFileUploadWorker
         {
             var fileName = _sharedFileDefinition.GetFileName(slice.PartNumber);
             _logger.LogError(ex,
-                "Error while uploading slice {Number} for {FileName} (worker {WorkerId}), sharedFileDefinitionId:{sharedFileDefinitionId} ",
+                "Error while uploading slice {Number} for {FileName} (worker {WorkerId}), SharedFileDefinitionId:{SharedFileDefinitionId} ",
                 slice.PartNumber, fileName, workerId, _sharedFileDefinition.Id);
             
             throw;

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
@@ -29,10 +29,6 @@ public class FileUploadWorker : IFileUploadWorker
     
     private static int _workerTaskCounter;
     
-    private const int AttemptTimeoutFloorSeconds = 60;
-    private const int AttemptTimeoutCeilingSeconds = 120;
-    private const int SecondsPerMegabyteHeuristic = 3;
-    
     public FileUploadWorker(
         IPolicyFactory policyFactory,
         IFileTransferApiClient fileTransferApiClient,
@@ -86,65 +82,83 @@ public class FileUploadWorker : IFileUploadWorker
     public async Task UploadAvailableSlicesAdaptiveAsync(Channel<FileUploaderSlice> availableSlices, UploadProgressState progressState)
     {
         var workerId = Interlocked.Increment(ref _workerTaskCounter);
-        while (await availableSlices.Reader.WaitToReadAsync())
+        try
         {
-            if (!availableSlices.Reader.TryRead(out var slice))
+            while (await availableSlices.Reader.WaitToReadAsync(CancellationTokenSource.Token))
             {
-                continue;
-            }
-            
-            try
-            {
-                var sliceStart = Stopwatch.StartNew();
-                
-                await IncrementConcurrentAsync(progressState);
-                var policy = _policyFactory.BuildFileUploadPolicy();
-                var attempt = 0;
-                
-                var response = await policy.ExecuteAsync(async () =>
+                if (_exceptionOccurred.WaitOne(0))
                 {
-                    attempt++;
-                    
-                    return await ExecuteUploadAttemptAsync(slice, workerId, attempt, CancellationTokenSource.Token);
-                });
-                
-                EnsureSuccessOrThrow(response);
-                
-                var fileName = _sharedFileDefinition.GetFileName(slice.PartNumber);
-                var assertSw = Stopwatch.StartNew();
-                _logger.LogDebug("UploadAvailableSlice: worker {WorkerId} start asserting slice {Number} for {FileName}",
-                    workerId, slice.PartNumber, fileName);
-                
-                var transferParameters = new TransferParameters
+                    return;
+                }
+
+                if (!availableSlices.Reader.TryRead(out var slice))
                 {
-                    SessionId = _sharedFileDefinition.SessionId,
-                    SharedFileDefinition = _sharedFileDefinition,
-                    PartNumber = slice.PartNumber,
-                    PartSizeInBytes = slice.MemoryStream.Length
-                };
-                
-                await AssertSliceUploadedAsync(policy, transferParameters, workerId, slice.PartNumber, fileName, assertSw);
-                assertSw.Stop();
-                _logger.LogDebug(
-                    "UploadAvailableSlice: worker {WorkerId} finished asserting slice {Number} for {FileName} in {ElapsedMs} ms",
-                    workerId, slice.PartNumber, fileName, assertSw.ElapsedMilliseconds);
-                
-                // Success path bookkeeping
-                await UpdateProgressOnSuccessAsync(progressState, slice, sliceStart);
+                    continue;
+                }
+
+                try
+                {
+                    var sliceStart = Stopwatch.StartNew();
+
+                    await IncrementConcurrentAsync(progressState);
+                    var policy = _policyFactory.BuildFileUploadPolicy();
+                    var attempt = 0;
+
+                    var response = await policy.ExecuteAsync(async () =>
+                    {
+                        attempt++;
+
+                        return await ExecuteUploadAttemptAsync(slice, workerId, attempt, CancellationTokenSource.Token);
+                    });
+
+                    if (!response.IsSuccess && CancellationTokenSource.IsCancellationRequested && _exceptionOccurred.WaitOne(0))
+                    {
+                        return;
+                    }
+
+                    EnsureSuccessOrThrow(response);
+
+                    var fileName = _sharedFileDefinition.GetFileName(slice.PartNumber);
+                    var assertSw = Stopwatch.StartNew();
+                    _logger.LogDebug("UploadAvailableSlice: worker {WorkerId} start asserting slice {Number} for {FileName}",
+                        workerId, slice.PartNumber, fileName);
+
+                    var transferParameters = new TransferParameters
+                    {
+                        SessionId = _sharedFileDefinition.SessionId,
+                        SharedFileDefinition = _sharedFileDefinition,
+                        PartNumber = slice.PartNumber,
+                        PartSizeInBytes = slice.MemoryStream.Length
+                    };
+
+                    await AssertSliceUploadedAsync(policy, transferParameters, workerId, slice.PartNumber, fileName, assertSw);
+                    assertSw.Stop();
+                    _logger.LogDebug(
+                        "UploadAvailableSlice: worker {WorkerId} finished asserting slice {Number} for {FileName} in {ElapsedMs} ms",
+                        workerId, slice.PartNumber, fileName, assertSw.ElapsedMilliseconds);
+
+                    await UpdateProgressOnSuccessAsync(progressState, slice, sliceStart);
+                }
+                catch (OperationCanceledException) when (CancellationTokenSource.IsCancellationRequested && _exceptionOccurred.WaitOne(0))
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    await HandleUploadExceptionAsync(progressState, ex, workerId);
+
+                    return;
+                }
+                finally
+                {
+                    DisposeSlice(slice);
+                    await DecrementConcurrentAsync(progressState);
+                }
             }
-            catch (Exception ex)
-            {
-                await HandleUploadExceptionAsync(progressState, ex, workerId);
-                
-                return;
-            }
-            finally
-            {
-                DisposeSlice(slice);
-                await DecrementConcurrentAsync(progressState);
-                
-                // No final release here: attempts handled slot release per attempt
-            }
+        }
+        catch (OperationCanceledException) when (CancellationTokenSource.IsCancellationRequested)
+        {
+            return;
         }
         
         await CompleteIfFinishedAsync(progressState);
@@ -154,13 +168,23 @@ public class FileUploadWorker : IFileUploadWorker
         CancellationToken globalToken)
     {
         var attemptStart = DateTime.UtcNow;
-        var timeoutSec = ComputeAttemptTimeoutSeconds(slice);
+        var currentChunkSizeBytes = _adaptiveUploadController.CurrentChunkSizeBytes;
+        var timeoutSec = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            slice.MemoryStream.Length,
+            attempt,
+            currentChunkSizeBytes);
         using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(globalToken);
         attemptCts.CancelAfter(TimeSpan.FromSeconds(timeoutSec));
         
         var beforeWait = _uploadSlots.CurrentCount;
-        _logger.LogDebug("UploadAvailableSlice: worker {WorkerId} waiting for upload slot (available {Available})",
-            workerId, beforeWait);
+        _logger.LogDebug(
+            "UploadAvailableSlice: worker {WorkerId} waiting for upload slot (available {Available}), attempt {Attempt}, timeout {TimeoutSec}s, slice {SliceKb} KB, currentChunk {CurrentChunkKb} KB",
+            workerId,
+            beforeWait,
+            attempt,
+            timeoutSec,
+            Math.Round(slice.MemoryStream.Length / 1024d),
+            Math.Round(currentChunkSizeBytes / 1024d));
         
         var acquired = false;
         try
@@ -267,19 +291,6 @@ public class FileUploadWorker : IFileUploadWorker
                     workerId, attempt);
             }
         }
-    }
-    
-    private static int ComputeAttemptTimeoutSeconds(FileUploaderSlice slice)
-    {
-        return ComputeAttemptTimeoutSeconds(slice.MemoryStream.Length);
-    }
-    
-    private static int ComputeAttemptTimeoutSeconds(long sliceLengthBytes)
-    {
-        var sizeMb = Math.Max(1, (int)Math.Ceiling(sliceLengthBytes / (1024d * 1024d)));
-        var timeoutSec = Math.Clamp(SecondsPerMegabyteHeuristic * sizeMb, AttemptTimeoutFloorSeconds, AttemptTimeoutCeilingSeconds);
-        
-        return timeoutSec;
     }
     
     private static UploadFailureKind RefineFailureKind(UploadFailureKind kind, CancellationTokenSource attemptCts,
@@ -414,6 +425,7 @@ public class FileUploadWorker : IFileUploadWorker
         }
         
         _exceptionOccurred.Set();
+        await CancellationTokenSource.CancelAsync();
     }
     
     private void DisposeSlice(FileUploaderSlice slice)

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
@@ -12,37 +12,46 @@ public static class UploadAttemptTimeoutPolicy
     
     public static int ComputeTimeoutSeconds(long sliceLengthBytes, int attempt, int currentChunkSizeBytes)
     {
-        var timeoutSec = ComputeBaseTimeoutSeconds(sliceLengthBytes);
+        var timeoutSec = (long)ComputeBaseTimeoutSeconds(sliceLengthBytes);
         if (attempt <= 1)
         {
-            return timeoutSec;
+            return (int)timeoutSec;
         }
         
         var staleChunkPenalty = ComputeStaleChunkPenaltySeconds(sliceLengthBytes, currentChunkSizeBytes);
         timeoutSec += (attempt - 1) * RetryGrowthSeconds + staleChunkPenalty;
         
-        return Math.Clamp(timeoutSec, AttemptTimeoutFloorSeconds, AttemptTimeoutCeilingSeconds);
+        return (int)Math.Clamp(timeoutSec, AttemptTimeoutFloorSeconds, AttemptTimeoutCeilingSeconds);
     }
     
     private static int ComputeBaseTimeoutSeconds(long sliceLengthBytes)
     {
-        var sizeMb = Math.Max(1, (int)Math.Ceiling(sliceLengthBytes / (1024d * 1024d)));
+        var sizeMb = Math.Max(1d, Math.Ceiling(sliceLengthBytes / (1024d * 1024d)));
+        var ceilingSizeMb = Math.Ceiling(AttemptTimeoutCeilingSeconds / (double)SecondsPerMegabyteHeuristic);
+        if (sizeMb >= ceilingSizeMb)
+        {
+            return AttemptTimeoutCeilingSeconds;
+        }
         
         return Math.Clamp(
-            SecondsPerMegabyteHeuristic * sizeMb,
+            SecondsPerMegabyteHeuristic * (int)sizeMb,
             AttemptTimeoutFloorSeconds,
             AttemptTimeoutCeilingSeconds);
     }
     
-    private static int ComputeStaleChunkPenaltySeconds(long sliceLengthBytes, int currentChunkSizeBytes)
+    private static long ComputeStaleChunkPenaltySeconds(long sliceLengthBytes, int currentChunkSizeBytes)
     {
         if (currentChunkSizeBytes <= 0 || sliceLengthBytes <= currentChunkSizeBytes)
         {
             return 0;
         }
         
-        var chunkRatio = (int)Math.Ceiling(sliceLengthBytes / (double)currentChunkSizeBytes);
+        var chunkRatio = Math.Ceiling(sliceLengthBytes / (double)currentChunkSizeBytes);
+        if (chunkRatio >= AttemptTimeoutCeilingSeconds / (double)StaleChunkPenaltySeconds + 1)
+        {
+            return AttemptTimeoutCeilingSeconds;
+        }
         
-        return (chunkRatio - 1) * StaleChunkPenaltySeconds;
+        return (long)(chunkRatio - 1) * StaleChunkPenaltySeconds;
     }
 }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
@@ -19,7 +19,7 @@ public static class UploadAttemptTimeoutPolicy
         }
         
         var staleChunkPenalty = ComputeStaleChunkPenaltySeconds(sliceLengthBytes, currentChunkSizeBytes);
-        timeoutSec += (attempt - 1) * RetryGrowthSeconds + staleChunkPenalty;
+        timeoutSec += (long)(attempt - 1) * RetryGrowthSeconds + staleChunkPenalty;
         
         return (int)Math.Clamp(timeoutSec, AttemptTimeoutFloorSeconds, AttemptTimeoutCeilingSeconds);
     }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
@@ -5,7 +5,7 @@ namespace ByteSync.Services.Communications.Transfers.Uploading;
 public static class UploadAttemptTimeoutPolicy
 {
     private const int AttemptTimeoutFloorSeconds = 60;
-    private const int AttemptTimeoutCeilingSeconds = 120;
+    private const int AttemptTimeoutCeilingSeconds = 180;
     private const int SecondsPerMegabyteHeuristic = 3;
     private const int RetryGrowthSeconds = 15;
     private const int StaleChunkPenaltySeconds = 5;

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace ByteSync.Services.Communications.Transfers.Uploading;
+
+public static class UploadAttemptTimeoutPolicy
+{
+    private const int AttemptTimeoutFloorSeconds = 60;
+    private const int AttemptTimeoutCeilingSeconds = 120;
+    private const int SecondsPerMegabyteHeuristic = 3;
+    private const int RetryGrowthSeconds = 15;
+    private const int StaleChunkPenaltySeconds = 5;
+    
+    public static int ComputeTimeoutSeconds(long sliceLengthBytes, int attempt, int currentChunkSizeBytes)
+    {
+        var timeoutSec = ComputeBaseTimeoutSeconds(sliceLengthBytes);
+        if (attempt <= 1)
+        {
+            return timeoutSec;
+        }
+        
+        var staleChunkPenalty = ComputeStaleChunkPenaltySeconds(sliceLengthBytes, currentChunkSizeBytes);
+        timeoutSec += (attempt - 1) * RetryGrowthSeconds + staleChunkPenalty;
+        
+        return Math.Clamp(timeoutSec, AttemptTimeoutFloorSeconds, AttemptTimeoutCeilingSeconds);
+    }
+    
+    private static int ComputeBaseTimeoutSeconds(long sliceLengthBytes)
+    {
+        var sizeMb = Math.Max(1, (int)Math.Ceiling(sliceLengthBytes / (1024d * 1024d)));
+        
+        return Math.Clamp(
+            SecondsPerMegabyteHeuristic * sizeMb,
+            AttemptTimeoutFloorSeconds,
+            AttemptTimeoutCeilingSeconds);
+    }
+    
+    private static int ComputeStaleChunkPenaltySeconds(long sliceLengthBytes, int currentChunkSizeBytes)
+    {
+        if (currentChunkSizeBytes <= 0 || sliceLengthBytes <= currentChunkSizeBytes)
+        {
+            return 0;
+        }
+        
+        var chunkRatio = (int)Math.Ceiling(sliceLengthBytes / (double)currentChunkSizeBytes);
+        
+        return (chunkRatio - 1) * StaleChunkPenaltySeconds;
+    }
+}

--- a/src/ByteSync.Common/Business/Communications/Transfers/UploadFailureKind.cs
+++ b/src/ByteSync.Common/Business/Communications/Transfers/UploadFailureKind.cs
@@ -6,4 +6,5 @@ public enum UploadFailureKind
     ServerError = 1,
     ClientCancellation = 2,
     ClientTimeout = 3,
+    ClientNetworkError = 4,
 }

--- a/src/ByteSync.Common/Business/Communications/Transfers/UploadFileResponse.cs
+++ b/src/ByteSync.Common/Business/Communications/Transfers/UploadFileResponse.cs
@@ -66,4 +66,16 @@ public class UploadFileResponse
             FailureKind = UploadFailureKind.ClientTimeout,
         };
     }
+
+    public static UploadFileResponse ClientNetworkError(Exception exception)
+    {
+        return new UploadFileResponse
+        {
+            IsSuccess = false,
+            StatusCode = 0,
+            ErrorMessage = exception.Message,
+            Exception = exception,
+            FailureKind = UploadFailureKind.ClientNetworkError,
+        };
+    }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/CloudflareR2UploadStrategyTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/CloudflareR2UploadStrategyTests.cs
@@ -27,14 +27,27 @@ public class CloudflareR2UploadStrategyTests
     
     private static (CloudflareR2UploadStrategy strategy, Mock<HttpMessageHandler> handler) CreateStrategy()
     {
+        var (strategy, handler, _) = CreateStrategyWithCreatedClients();
+        return (strategy, handler);
+    }
+
+    private static (CloudflareR2UploadStrategy strategy, Mock<HttpMessageHandler> handler, List<HttpClient> createdClients)
+        CreateStrategyWithCreatedClients()
+    {
         var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var createdClients = new List<HttpClient>();
         var factory = new Mock<IHttpClientFactory>();
         factory
             .Setup(f => f.CreateClient(It.IsAny<string>()))
-            .Returns(() => new HttpClient(handler.Object, disposeHandler: false));
+            .Returns(() =>
+            {
+                var httpClient = new HttpClient(handler.Object, disposeHandler: false);
+                createdClients.Add(httpClient);
+                return httpClient;
+            });
         
         var strategy = new CloudflareR2UploadStrategy(NullLogger<CloudflareR2UploadStrategy>.Instance, factory.Object);
-        return (strategy, handler);
+        return (strategy, handler, createdClients);
     }
     
     private static void SetupHandler(Mock<HttpMessageHandler> handler, HttpResponseMessage response)
@@ -70,6 +83,18 @@ public class CloudflareR2UploadStrategyTests
         response.FailureKind.Should().Be(UploadFailureKind.None);
     }
     
+    [Test]
+    public async Task UploadAsync_ShouldLetCallerTokenControlAttemptTimeout()
+    {
+        var (strategy, handler, createdClients) = CreateStrategyWithCreatedClients();
+        SetupHandler(handler, new HttpResponseMessage(HttpStatusCode.OK));
+
+        await strategy.UploadAsync(CreateSlice(), CreateLocation(), CancellationToken.None);
+
+        createdClients.Should().ContainSingle();
+        createdClients[0].Timeout.Should().Be(Timeout.InfiniteTimeSpan);
+    }
+
     [Test]
     public async Task UploadAsync_On500_ShouldReturnServerFailure_WithRealStatusCode()
     {

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
@@ -2,6 +2,8 @@ using ByteSync.Common.Business.Communications.Transfers;
 using ByteSync.Services.Communications.Transfers.Strategies;
 using FluentAssertions;
 using NUnit.Framework;
+using System.Net.Http;
+using System.Net.Sockets;
 
 namespace ByteSync.Client.UnitTests.Services.Communications.Transfers.Strategies;
 
@@ -80,16 +82,32 @@ public class UploadFailureClassifierTests
     }
     
     [Test]
-    public void Classify_HttpRequestException_ShouldReturnServerError500()
+    public void Classify_HttpRequestExceptionWithoutSocketFailure_ShouldReturnServerError500()
     {
         using var cts = new CancellationTokenSource();
         var ex = new HttpRequestException("network issue");
-        
+
         var response = UploadFailureClassifier.Classify(ex, cts.Token);
-        
+
         response.IsSuccess.Should().BeFalse();
         response.StatusCode.Should().Be(500);
         response.FailureKind.Should().Be(UploadFailureKind.ServerError);
+        response.Exception.Should().BeSameAs(ex);
+    }
+
+    [Test]
+    public void Classify_HttpRequestExceptionWithConnectionReset_ShouldReturnClientNetworkError()
+    {
+        using var cts = new CancellationTokenSource();
+        var socketException = new SocketException((int)SocketError.ConnectionReset);
+        var ioException = new IOException("transport closed", socketException);
+        var ex = new HttpRequestException("copy failed", ioException);
+
+        var response = UploadFailureClassifier.Classify(ex, cts.Token);
+
+        response.IsSuccess.Should().BeFalse();
+        response.StatusCode.Should().Be(0);
+        response.FailureKind.Should().Be(UploadFailureKind.ClientNetworkError);
         response.Exception.Should().BeSameAs(ex);
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
@@ -110,4 +110,18 @@ public class UploadFailureClassifierTests
         response.FailureKind.Should().Be(UploadFailureKind.ClientNetworkError);
         response.Exception.Should().BeSameAs(ex);
     }
+
+    [Test]
+    public void Classify_DirectSocketExceptionWithConnectionReset_ShouldReturnClientNetworkError()
+    {
+        using var cts = new CancellationTokenSource();
+        var ex = new SocketException((int)SocketError.ConnectionReset);
+
+        var response = UploadFailureClassifier.Classify(ex, cts.Token);
+
+        response.IsSuccess.Should().BeFalse();
+        response.StatusCode.Should().Be(0);
+        response.FailureKind.Should().Be(UploadFailureKind.ClientNetworkError);
+        response.Exception.Should().BeSameAs(ex);
+    }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
@@ -199,7 +199,22 @@ public class AdaptiveUploadControllerTests
         _controller.CurrentChunkSizeBytes.Should().BeLessThan(500 * 1024);
         _controller.CurrentChunkSizeBytes.Should().Be(375 * 1024);
     }
-    
+
+    [Test]
+    public void ClientNetworkErrors_DownscaleBelowInitialChunkSize_WhenAtMinParallelism()
+    {
+        // Arrange
+        _controller.CurrentParallelism.Should().Be(2);
+        _controller.CurrentChunkSizeBytes.Should().Be(500 * 1024);
+
+        // Act
+        FeedClientNetworkErrors(_controller, 2);
+
+        // Assert
+        _controller.CurrentParallelism.Should().Be(2);
+        _controller.CurrentChunkSizeBytes.Should().Be(375 * 1024);
+    }
+
     [Test]
     public void ClientTimeouts_ReduceParallelismFirst_WhenAboveMinParallelism()
     {
@@ -280,7 +295,21 @@ public class AdaptiveUploadControllerTests
                 failureKind: UploadFailureKind.ClientTimeout);
         }
     }
-    
+
+    private static void FeedClientNetworkErrors(AdaptiveUploadController controller, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            RecordUploadResult(
+                controller,
+                TimeSpan.FromSeconds(90),
+                isSuccess: false,
+                partNumber: i + 1,
+                statusCode: 0,
+                failureKind: UploadFailureKind.ClientNetworkError);
+        }
+    }
+
     private static void RecordUploadResult(
         AdaptiveUploadController controller,
         TimeSpan elapsed,

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileSlicerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileSlicerTests.cs
@@ -168,7 +168,57 @@ public class FileSlicerTests
         // Channel should be completed
         _availableSlices.Reader.Completion.IsCompleted.Should().BeTrue();
     }
-    
+
+    [Test]
+    public async Task SliceAndEncryptAsync_WhenChannelClosesAfterSliceCreated_ShouldDisposeSlice()
+    {
+        // Arrange
+        var stream = new MemoryStream(new byte[128]);
+        var slice = new FileUploaderSlice(1, stream);
+
+        _mockSlicerEncrypter.Setup(x => x.SliceAndEncrypt())
+            .Callback(() =>
+            {
+                _exceptionOccurred.Set();
+                _availableSlices.Writer.TryComplete();
+            })
+            .ReturnsAsync(slice);
+
+        // Act
+        await _fileSlicer.SliceAndEncryptAsync(_sharedFileDefinition, _progressState);
+
+        // Assert
+        _progressState.TotalCreatedSlices.Should().Be(1);
+        var readDisposedStream = () => _ = stream.Length;
+        readDisposedStream.Should().Throw<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task SliceAndEncryptAdaptiveAsync_WhenChannelClosesAfterSliceCreated_ShouldDisposeSlice()
+    {
+        // Arrange
+        var stream = new MemoryStream(new byte[128]);
+        var slice = new FileUploaderSlice(1, stream);
+
+        _mockAdaptiveController.Setup(x => x.CurrentChunkSizeBytes).Returns(64 * 1024);
+        _mockAdaptiveController.Setup(x => x.GetNextChunkSizeBytes()).Returns(64 * 1024);
+        _mockSlicerEncrypter.Setup(x => x.SliceAndEncrypt())
+            .Callback(() =>
+            {
+                _exceptionOccurred.Set();
+                _availableSlices.Writer.TryComplete();
+            })
+            .ReturnsAsync(slice);
+
+        // Act
+        await _fileSlicer.SliceAndEncryptAdaptiveAsync(_sharedFileDefinition, _progressState);
+
+        // Assert
+        _progressState.TotalCreatedSlices.Should().Be(1);
+        var readDisposedStream = () => _ = stream.Length;
+        readDisposedStream.Should().Throw<ObjectDisposedException>();
+    }
+
     [Test]
     public async Task SliceAndEncryptAsync_WithMultipleSlices_ShouldProcessAllSlices()
     {

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileUploadCoordinatorTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileUploadCoordinatorTests.cs
@@ -178,6 +178,28 @@ public class FileUploadCoordinatorTests
     }
     
     [Test]
+    public async Task AvailableSlices_ShouldApplyTightBackpressure()
+    {
+        // Arrange
+        var first = new FileUploaderSlice(1, new MemoryStream());
+        var second = new FileUploaderSlice(2, new MemoryStream());
+        var third = new FileUploaderSlice(3, new MemoryStream());
+
+        // Act
+        await _coordinator.AvailableSlices.Writer.WriteAsync(first);
+        await _coordinator.AvailableSlices.Writer.WriteAsync(second);
+        var thirdWrite = _coordinator.AvailableSlices.Writer.WriteAsync(third).AsTask();
+
+        // Assert
+        thirdWrite.IsCompleted.Should().BeFalse();
+
+        var readSlice = await _coordinator.AvailableSlices.Reader.ReadAsync();
+        readSlice.Should().Be(first);
+
+        await thirdWrite.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
     public void MultipleSetExceptionCalls_ShouldNotThrow()
     {
         // Arrange

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileUploadWorkerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileUploadWorkerTests.cs
@@ -414,7 +414,7 @@ public class FileUploadWorkerTests
 
                 if (slice.PartNumber == 1)
                 {
-                    firstUploadCanFail.Wait(TimeSpan.FromSeconds(5));
+                    firstUploadCanFail.Wait(TimeSpan.FromSeconds(5), CancellationToken.None);
 
                     return UploadFileResponse.Failure(500, "server failure");
                 }
@@ -457,5 +457,35 @@ public class FileUploadWorkerTests
         secondUploadCanceled.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
         _exceptionOccurred.WaitOne(0).Should().BeTrue();
         _progressState.Exceptions.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task UploadAvailableSlicesAdaptiveAsync_WhenWorkerFails_ShouldDisposeQueuedSlices()
+    {
+        // Arrange
+        var activeSlice = new FileUploaderSlice(1, new MemoryStream(new byte[64 * 1024]));
+        var queuedStream = new MemoryStream(new byte[64 * 1024]);
+        var queuedSlice = new FileUploaderSlice(2, queuedStream);
+        var mockUploadStrategy = new Mock<IUploadStrategy>();
+        var mockUploadLocation = new FileStorageLocation("https://test.example.com/upload", StorageProvider.CloudflareR2);
+
+        mockUploadStrategy.Setup(x =>
+                x.UploadAsync(It.IsAny<FileUploaderSlice>(), It.IsAny<FileStorageLocation>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UploadFileResponse.Failure(500, "server failure"));
+
+        _mockStrategies.Setup(x => x[StorageProvider.CloudflareR2]).Returns(mockUploadStrategy.Object);
+        _mockFileTransferApiClient.Setup(x => x.GetUploadFileStorageLocation(It.IsAny<TransferParameters>()))
+            .ReturnsAsync(mockUploadLocation);
+
+        await _availableSlices.Writer.WriteAsync(activeSlice);
+        await _availableSlices.Writer.WriteAsync(queuedSlice);
+        _availableSlices.Writer.Complete();
+
+        // Act
+        await _fileUploadWorker.UploadAvailableSlicesAdaptiveAsync(_availableSlices, _progressState);
+
+        // Assert
+        var readQueuedStream = () => _ = queuedStream.Length;
+        readQueuedStream.Should().Throw<ObjectDisposedException>();
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileUploadWorkerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/FileUploadWorkerTests.cs
@@ -61,6 +61,8 @@ public class FileUploadWorkerTests
         _availableSlices = Channel.CreateBounded<FileUploaderSlice>(8);
         _progressState = new UploadProgressState();
         _mockAdaptiveController = new Mock<IAdaptiveUploadController>();
+        _mockAdaptiveController.Setup(x => x.CurrentChunkSizeBytes).Returns(500 * 1024);
+        _mockAdaptiveController.Setup(x => x.CurrentParallelism).Returns(2);
         
         _fileUploadWorker = new FileUploadWorker(
             _mockPolicyFactory.Object,
@@ -340,5 +342,120 @@ public class FileUploadWorkerTests
             result.StatusCode == 503 &&
             result.FileId == _sharedFileDefinition.Id &&
             result.FailureKind == UploadFailureKind.ServerError)), Times.AtLeastOnce);
+    }
+
+    [Test]
+    public async Task UploadAvailableSlicesAdaptiveAsync_WhenClientTimeoutIsRetried_ShouldKeepFailureKindAndEventuallySucceed()
+    {
+        // Arrange
+        var slice = new FileUploaderSlice(1, new MemoryStream(new byte[625 * 1024]));
+        var mockUploadStrategy = new Mock<IUploadStrategy>();
+        var mockUploadLocation = new FileStorageLocation("https://test.example.com/upload", StorageProvider.CloudflareR2);
+        var attempt = 0;
+
+        _policy = Policy<UploadFileResponse>
+            .HandleResult(x => !x.IsSuccess)
+            .RetryAsync(1, onRetry: (_, _, _) => { });
+        _mockPolicyFactory.Setup(x => x.BuildFileUploadPolicy()).Returns(_policy);
+        _mockAdaptiveController.Setup(x => x.CurrentChunkSizeBytes).Returns(64 * 1024);
+
+        mockUploadStrategy.Setup(x =>
+                x.UploadAsync(It.IsAny<FileUploaderSlice>(), It.IsAny<FileStorageLocation>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                attempt++;
+
+                return attempt == 1
+                    ? UploadFileResponse.ClientTimeout(new TaskCanceledException("attempt timed out"))
+                    : UploadFileResponse.Success(200);
+            });
+
+        _mockStrategies.Setup(x => x[StorageProvider.CloudflareR2]).Returns(mockUploadStrategy.Object);
+        _mockFileTransferApiClient.Setup(x => x.GetUploadFileStorageLocation(It.IsAny<TransferParameters>()))
+            .ReturnsAsync(mockUploadLocation);
+        _mockFileTransferApiClient.Setup(x => x.AssertFilePartIsUploaded(It.IsAny<TransferParameters>()))
+            .Returns(Task.CompletedTask);
+        _progressState.TotalCreatedSlices = 1;
+
+        await _availableSlices.Writer.WriteAsync(slice);
+        _availableSlices.Writer.Complete();
+
+        // Act
+        await _fileUploadWorker.UploadAvailableSlicesAdaptiveAsync(_availableSlices, _progressState);
+
+        // Assert
+        attempt.Should().Be(2);
+        _uploadingIsFinished.WaitOne(1000).Should().BeTrue();
+        _mockAdaptiveController.Verify(x => x.RecordUploadResult(It.Is<UploadResult>(result =>
+            !result.IsSuccess &&
+            result.FailureKind == UploadFailureKind.ClientTimeout)), Times.Once);
+        _mockAdaptiveController.Verify(x => x.RecordUploadResult(It.Is<UploadResult>(result =>
+            result.IsSuccess &&
+            result.FailureKind == UploadFailureKind.None)), Times.Once);
+    }
+
+    [Test]
+    public async Task UploadAvailableSlicesAdaptiveAsync_WhenOneWorkerFails_ShouldCancelOtherWorkers()
+    {
+        // Arrange
+        var firstSlice = new FileUploaderSlice(1, new MemoryStream(new byte[64 * 1024]));
+        var secondSlice = new FileUploaderSlice(2, new MemoryStream(new byte[64 * 1024]));
+        var mockUploadStrategy = new Mock<IUploadStrategy>();
+        var mockUploadLocation = new FileStorageLocation("https://test.example.com/upload", StorageProvider.CloudflareR2);
+        using var bothUploadsStarted = new CountdownEvent(2);
+        using var firstUploadCanFail = new ManualResetEventSlim(false);
+        using var secondUploadCanceled = new ManualResetEventSlim(false);
+
+        mockUploadStrategy.Setup(x =>
+                x.UploadAsync(It.IsAny<FileUploaderSlice>(), It.IsAny<FileStorageLocation>(), It.IsAny<CancellationToken>()))
+            .Returns<FileUploaderSlice, FileStorageLocation, CancellationToken>(async (slice, _, cancellationToken) =>
+            {
+                bothUploadsStarted.Signal();
+
+                if (slice.PartNumber == 1)
+                {
+                    firstUploadCanFail.Wait(TimeSpan.FromSeconds(5));
+
+                    return UploadFileResponse.Failure(500, "server failure");
+                }
+
+                firstUploadCanFail.Set();
+
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+
+                    return UploadFileResponse.Success(200);
+                }
+                catch (OperationCanceledException ex)
+                {
+                    secondUploadCanceled.Set();
+
+                    return UploadFileResponse.ClientCancellation(ex);
+                }
+            });
+
+        _mockStrategies.Setup(x => x[StorageProvider.CloudflareR2]).Returns(mockUploadStrategy.Object);
+        _mockFileTransferApiClient.Setup(x => x.GetUploadFileStorageLocation(It.IsAny<TransferParameters>()))
+            .ReturnsAsync(mockUploadLocation);
+        _progressState.TotalCreatedSlices = 2;
+
+        var firstWorker = _fileUploadWorker.UploadAvailableSlicesAdaptiveAsync(_availableSlices, _progressState);
+        var secondWorker = _fileUploadWorker.UploadAvailableSlicesAdaptiveAsync(_availableSlices, _progressState);
+
+        await _availableSlices.Writer.WriteAsync(firstSlice);
+        await _availableSlices.Writer.WriteAsync(secondSlice);
+        _availableSlices.Writer.Complete();
+
+        // Act
+        bothUploadsStarted.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        var allWorkers = Task.WhenAll(firstWorker, secondWorker);
+        var completed = await Task.WhenAny(allWorkers, Task.Delay(TimeSpan.FromSeconds(3)));
+
+        // Assert
+        completed.Should().Be(allWorkers);
+        secondUploadCanceled.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
+        _exceptionOccurred.WaitOne(0).Should().BeTrue();
+        _progressState.Exceptions.Should().HaveCount(1);
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
@@ -56,7 +56,20 @@ public class UploadAttemptTimeoutPolicyTests
             currentChunkSizeBytes: 64 * 1024);
         
         // Assert
-        timeout.Should().Be(120);
+        timeout.Should().Be(180);
+    }
+
+    [Test]
+    public void ComputeTimeoutSeconds_ForLargeStaleSliceAtLowBandwidth_ShouldAllowMoreThanTwoMinutes()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            1969 * 1024,
+            attempt: 6,
+            currentChunkSizeBytes: 500 * 1024);
+
+        // Assert
+        timeout.Should().Be(150);
     }
 
     [Test]
@@ -69,7 +82,7 @@ public class UploadAttemptTimeoutPolicyTests
             currentChunkSizeBytes: 64 * 1024);
 
         // Assert
-        timeout.Should().Be(120);
+        timeout.Should().Be(180);
     }
 
     [Test]
@@ -82,6 +95,6 @@ public class UploadAttemptTimeoutPolicyTests
             currentChunkSizeBytes: 1);
 
         // Assert
-        timeout.Should().Be(120);
+        timeout.Should().Be(180);
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
@@ -58,4 +58,30 @@ public class UploadAttemptTimeoutPolicyTests
         // Assert
         timeout.Should().Be(120);
     }
+
+    [Test]
+    public void ComputeTimeoutSeconds_WithHugeSlice_ShouldNotOverflow()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            long.MaxValue,
+            attempt: 1,
+            currentChunkSizeBytes: 64 * 1024);
+
+        // Assert
+        timeout.Should().Be(120);
+    }
+
+    [Test]
+    public void ComputeTimeoutSeconds_WithHugeStaleRatio_ShouldNotOverflow()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            long.MaxValue,
+            attempt: 2,
+            currentChunkSizeBytes: 1);
+
+        // Assert
+        timeout.Should().Be(120);
+    }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
@@ -1,0 +1,61 @@
+using ByteSync.Services.Communications.Transfers.Uploading;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace ByteSync.Client.UnitTests.Services.Communications.Transfers.Uploading;
+
+[TestFixture]
+public class UploadAttemptTimeoutPolicyTests
+{
+    [Test]
+    public void ComputeTimeoutSeconds_FirstAttempt_ShouldUseFloorForSmallSlices()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            500 * 1024,
+            attempt: 1,
+            currentChunkSizeBytes: 500 * 1024);
+        
+        // Assert
+        timeout.Should().Be(60);
+    }
+    
+    [Test]
+    public void ComputeTimeoutSeconds_RetryForStaleLargeSlice_ShouldIncreaseBudget()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            625 * 1024,
+            attempt: 2,
+            currentChunkSizeBytes: 64 * 1024);
+        
+        // Assert
+        timeout.Should().Be(120);
+    }
+    
+    [Test]
+    public void ComputeTimeoutSeconds_RetryForCurrentChunkSizedSlice_ShouldGrowGradually()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            64 * 1024,
+            attempt: 2,
+            currentChunkSizeBytes: 64 * 1024);
+        
+        // Assert
+        timeout.Should().Be(75);
+    }
+    
+    [Test]
+    public void ComputeTimeoutSeconds_ShouldNotExceedCeiling()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            16 * 1024 * 1024,
+            attempt: 10,
+            currentChunkSizeBytes: 64 * 1024);
+        
+        // Assert
+        timeout.Should().Be(120);
+    }
+}


### PR DESCRIPTION
## Summary
- Increase retry timeout budgets for stale upload slices created before adaptive downscale catches up.
- Reduce queued slice backlog so new slices reflect the latest adaptive chunk size sooner.
- Cancel sibling upload workers after a fatal upload failure to avoid uploads continuing after terminal errors.

## Test plan
- `dotnet build ByteSync.sln --artifacts-path ".artifacts/pr3-build-output"`
- `dotnet test tests/ByteSync.Client.UnitTests/ByteSync.Client.UnitTests.csproj --artifacts-path ".artifacts/pr3-test-output"`
- `dotnet test tests/ByteSync.Client.IntegrationTests/ByteSync.Client.IntegrationTests.csproj --filter Upload_SliceAndParallelism_Tests --artifacts-path ".artifacts/pr3-integration-output"`

Made with [Cursor](https://cursor.com)