### PR TITLE
[fix] Improve stale upload slice resilience

### DIFF
--- a/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
@@ -21,6 +21,11 @@ public static class UploadFailureClassifier
             return UploadFileResponse.ClientTimeout(exception);
         }
 
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return UploadFileResponse.ClientCancellation(exception);
+        }
+
         if (IsClientNetworkError(exception))
         {
             return UploadFileResponse.ClientNetworkError(exception);
@@ -51,9 +56,20 @@ public static class UploadFailureClassifier
                     or SocketError.HostUnreachable;
             }
 
+            if (current is IOException ioException && IsUnexpectedTransportClosure(ioException))
+            {
+                return true;
+            }
+
             current = current.InnerException;
         }
 
         return false;
+    }
+
+    private static bool IsUnexpectedTransportClosure(IOException exception)
+    {
+        return exception.Message.Contains("unexpected EOF", StringComparison.OrdinalIgnoreCase)
+            || exception.Message.Contains("0 bytes from the transport stream", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
@@ -43,6 +43,7 @@ public static class UploadFailureClassifier
             {
                 return socketException.SocketErrorCode is SocketError.ConnectionReset
                     or SocketError.ConnectionAborted
+                    or SocketError.OperationAborted
                     or SocketError.TimedOut
                     or SocketError.NetworkDown
                     or SocketError.NetworkUnreachable

--- a/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Strategies/UploadFailureClassifier.cs
@@ -9,6 +9,12 @@ namespace ByteSync.Services.Communications.Transfers.Strategies;
 
 public static class UploadFailureClassifier
 {
+    private static readonly string[] UnexpectedTransportClosureMessageFragments =
+    {
+        "unexpected EOF",
+        "0 bytes from the transport stream",
+    };
+
     public static UploadFileResponse Classify(Exception exception, CancellationToken cancellationToken)
     {
         if (exception is OperationCanceledException && cancellationToken.IsCancellationRequested)
@@ -56,7 +62,7 @@ public static class UploadFailureClassifier
                     or SocketError.HostUnreachable;
             }
 
-            if (current is IOException ioException && IsUnexpectedTransportClosure(ioException))
+            if (current is IOException ioException && HasUnexpectedTransportClosureMessage(ioException))
             {
                 return true;
             }
@@ -67,9 +73,16 @@ public static class UploadFailureClassifier
         return false;
     }
 
-    private static bool IsUnexpectedTransportClosure(IOException exception)
+    private static bool HasUnexpectedTransportClosureMessage(IOException exception)
     {
-        return exception.Message.Contains("unexpected EOF", StringComparison.OrdinalIgnoreCase)
-            || exception.Message.Contains("0 bytes from the transport stream", StringComparison.OrdinalIgnoreCase);
+        foreach (var fragment in UnexpectedTransportClosureMessageFragments)
+        {
+            if (exception.Message.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/AdaptiveUploadController.cs
@@ -15,6 +15,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
     private const int MIN_PARALLELISM = 2;
     private const int MAX_PARALLELISM = 4;
     private const int CLIENT_NETWORK_ISSUES_BEFORE_DOWNSCALE = 2;
+    private const double CLIENT_NETWORK_ISSUE_CHUNK_FACTOR = 0.5;
     
     private const double MULTIPLIER_2_X = 2.0;
     private const double MULTIPLIER_1_75_X = 1.75;
@@ -182,7 +183,7 @@ public class AdaptiveUploadController : IAdaptiveUploadController
             fileId ?? "-",
             _consecutiveClientNetworkIssues);
         _consecutiveClientNetworkIssues = 0;
-        Downscale(fileId, "client network issues");
+        DownscaleForClientNetworkIssue(fileId, failureKind);
     }
     
     private bool HandleBandwidthReset(bool isSuccess, int? statusCode)
@@ -257,6 +258,29 @@ public class AdaptiveUploadController : IAdaptiveUploadController
                 Math.Round(_currentChunkSizeBytes / 1024d));
         }
         
+        ResetWindow();
+    }
+
+    private void DownscaleForClientNetworkIssue(string? fileId, UploadFailureKind failureKind)
+    {
+        var previousParallelism = _currentParallelism;
+        var previousChunkSizeBytes = _currentChunkSizeBytes;
+
+        _currentParallelism = MIN_PARALLELISM;
+        _currentChunkSizeBytes = Math.Max(
+            MIN_CHUNK_SIZE_BYTES,
+            (int)Math.Round(_currentChunkSizeBytes * CLIENT_NETWORK_ISSUE_CHUNK_FACTOR));
+        _windowSize = _currentParallelism;
+
+        _logger.LogInformation(
+            "Adaptive: file {FileId} client network issue downscale ({FailureKind}). Parallelism {PrevParallelism}->{NextParallelism}, chunkSize {PrevChunkKb}->{NextChunkKb} KB",
+            fileId ?? "-",
+            failureKind,
+            previousParallelism,
+            _currentParallelism,
+            Math.Round(previousChunkSizeBytes / 1024d),
+            Math.Round(_currentChunkSizeBytes / 1024d));
+
         ResetWindow();
     }
     

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/FileUploadWorker.cs
@@ -174,18 +174,22 @@ public class FileUploadWorker : IFileUploadWorker
             slice.MemoryStream.Length,
             attempt,
             currentChunkSizeBytes);
+        var chunkRatio = currentChunkSizeBytes > 0
+            ? slice.MemoryStream.Length / (double)currentChunkSizeBytes
+            : 0d;
         using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(globalToken);
         attemptCts.CancelAfter(TimeSpan.FromSeconds(timeoutSec));
         
         var beforeWait = _uploadSlots.CurrentCount;
         _logger.LogDebug(
-            "UploadAvailableSlice: worker {WorkerId} waiting for upload slot (available {Available}), attempt {Attempt}, timeout {TimeoutSec}s, slice {SliceKb} KB, currentChunk {CurrentChunkKb} KB",
+            "UploadAvailableSlice: worker {WorkerId} waiting for upload slot (available {Available}), attempt {Attempt}, timeout {TimeoutSec}s, slice {SliceKb} KB, currentChunk {CurrentChunkKb} KB, chunkRatio {ChunkRatio}",
             workerId,
             beforeWait,
             attempt,
             timeoutSec,
             Math.Round(slice.MemoryStream.Length / 1024d),
-            Math.Round(currentChunkSizeBytes / 1024d));
+            Math.Round(currentChunkSizeBytes / 1024d),
+            Math.Round(chunkRatio, 2));
         
         var acquired = false;
         try

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
@@ -6,22 +6,26 @@ public static class UploadAttemptTimeoutPolicy
 {
     private const int AttemptTimeoutFloorSeconds = 60;
     private const int AttemptTimeoutCeilingSeconds = 180;
+    private const int ExtendedOversizedSliceTimeoutCeilingSeconds = 300;
     private const int SecondsPerMegabyteHeuristic = 3;
     private const int RetryGrowthSeconds = 15;
     private const int OversizedSliceSecondsPerCurrentChunk = 30;
+    private const int ExtendedOversizedSliceThresholdBytes = 1024 * 1024;
+    private const int ExtendedOversizedSliceChunkRatioThreshold = 8;
     
     public static int ComputeTimeoutSeconds(long sliceLengthBytes, int attempt, int currentChunkSizeBytes)
     {
+        var timeoutCeilingSeconds = ComputeTimeoutCeilingSeconds(sliceLengthBytes, currentChunkSizeBytes);
         var timeoutSec = Math.Max(
             (long)ComputeBaseTimeoutSeconds(sliceLengthBytes),
-            ComputeOversizedSliceTimeoutSeconds(sliceLengthBytes, currentChunkSizeBytes));
+            ComputeOversizedSliceTimeoutSeconds(sliceLengthBytes, currentChunkSizeBytes, timeoutCeilingSeconds));
 
         if (attempt > 1)
         {
             timeoutSec += (long)(attempt - 1) * RetryGrowthSeconds;
         }
         
-        return (int)Math.Clamp(timeoutSec, AttemptTimeoutFloorSeconds, AttemptTimeoutCeilingSeconds);
+        return (int)Math.Clamp(timeoutSec, AttemptTimeoutFloorSeconds, timeoutCeilingSeconds);
     }
     
     private static int ComputeBaseTimeoutSeconds(long sliceLengthBytes)
@@ -39,7 +43,24 @@ public static class UploadAttemptTimeoutPolicy
             AttemptTimeoutCeilingSeconds);
     }
     
-    private static long ComputeOversizedSliceTimeoutSeconds(long sliceLengthBytes, int currentChunkSizeBytes)
+    private static int ComputeTimeoutCeilingSeconds(long sliceLengthBytes, int currentChunkSizeBytes)
+    {
+        if (currentChunkSizeBytes <= 0 || sliceLengthBytes <= currentChunkSizeBytes)
+        {
+            return AttemptTimeoutCeilingSeconds;
+        }
+
+        var chunkRatio = Math.Ceiling(sliceLengthBytes / (double)currentChunkSizeBytes);
+        if (sliceLengthBytes >= ExtendedOversizedSliceThresholdBytes
+            && chunkRatio >= ExtendedOversizedSliceChunkRatioThreshold)
+        {
+            return ExtendedOversizedSliceTimeoutCeilingSeconds;
+        }
+
+        return AttemptTimeoutCeilingSeconds;
+    }
+
+    private static long ComputeOversizedSliceTimeoutSeconds(long sliceLengthBytes, int currentChunkSizeBytes, int timeoutCeilingSeconds)
     {
         if (currentChunkSizeBytes <= 0 || sliceLengthBytes <= currentChunkSizeBytes)
         {
@@ -47,9 +68,9 @@ public static class UploadAttemptTimeoutPolicy
         }
         
         var chunkRatio = Math.Ceiling(sliceLengthBytes / (double)currentChunkSizeBytes);
-        if (chunkRatio >= AttemptTimeoutCeilingSeconds / (double)OversizedSliceSecondsPerCurrentChunk)
+        if (chunkRatio >= timeoutCeilingSeconds / (double)OversizedSliceSecondsPerCurrentChunk)
         {
-            return AttemptTimeoutCeilingSeconds;
+            return timeoutCeilingSeconds;
         }
         
         return (long)chunkRatio * OversizedSliceSecondsPerCurrentChunk;

--- a/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
+++ b/src/ByteSync.Client/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicy.cs
@@ -8,18 +8,18 @@ public static class UploadAttemptTimeoutPolicy
     private const int AttemptTimeoutCeilingSeconds = 180;
     private const int SecondsPerMegabyteHeuristic = 3;
     private const int RetryGrowthSeconds = 15;
-    private const int StaleChunkPenaltySeconds = 5;
+    private const int OversizedSliceSecondsPerCurrentChunk = 30;
     
     public static int ComputeTimeoutSeconds(long sliceLengthBytes, int attempt, int currentChunkSizeBytes)
     {
-        var timeoutSec = (long)ComputeBaseTimeoutSeconds(sliceLengthBytes);
-        if (attempt <= 1)
+        var timeoutSec = Math.Max(
+            (long)ComputeBaseTimeoutSeconds(sliceLengthBytes),
+            ComputeOversizedSliceTimeoutSeconds(sliceLengthBytes, currentChunkSizeBytes));
+
+        if (attempt > 1)
         {
-            return (int)timeoutSec;
+            timeoutSec += (long)(attempt - 1) * RetryGrowthSeconds;
         }
-        
-        var staleChunkPenalty = ComputeStaleChunkPenaltySeconds(sliceLengthBytes, currentChunkSizeBytes);
-        timeoutSec += (long)(attempt - 1) * RetryGrowthSeconds + staleChunkPenalty;
         
         return (int)Math.Clamp(timeoutSec, AttemptTimeoutFloorSeconds, AttemptTimeoutCeilingSeconds);
     }
@@ -39,7 +39,7 @@ public static class UploadAttemptTimeoutPolicy
             AttemptTimeoutCeilingSeconds);
     }
     
-    private static long ComputeStaleChunkPenaltySeconds(long sliceLengthBytes, int currentChunkSizeBytes)
+    private static long ComputeOversizedSliceTimeoutSeconds(long sliceLengthBytes, int currentChunkSizeBytes)
     {
         if (currentChunkSizeBytes <= 0 || sliceLengthBytes <= currentChunkSizeBytes)
         {
@@ -47,11 +47,11 @@ public static class UploadAttemptTimeoutPolicy
         }
         
         var chunkRatio = Math.Ceiling(sliceLengthBytes / (double)currentChunkSizeBytes);
-        if (chunkRatio >= AttemptTimeoutCeilingSeconds / (double)StaleChunkPenaltySeconds + 1)
+        if (chunkRatio >= AttemptTimeoutCeilingSeconds / (double)OversizedSliceSecondsPerCurrentChunk)
         {
             return AttemptTimeoutCeilingSeconds;
         }
         
-        return (long)(chunkRatio - 1) * StaleChunkPenaltySeconds;
+        return (long)chunkRatio * OversizedSliceSecondsPerCurrentChunk;
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
@@ -124,4 +124,18 @@ public class UploadFailureClassifierTests
         response.FailureKind.Should().Be(UploadFailureKind.ClientNetworkError);
         response.Exception.Should().BeSameAs(ex);
     }
+
+    [Test]
+    public void Classify_DirectSocketExceptionWithOperationAborted_ShouldReturnClientNetworkError()
+    {
+        using var cts = new CancellationTokenSource();
+        var ex = new SocketException((int)SocketError.OperationAborted);
+
+        var response = UploadFailureClassifier.Classify(ex, cts.Token);
+
+        response.IsSuccess.Should().BeFalse();
+        response.StatusCode.Should().Be(0);
+        response.FailureKind.Should().Be(UploadFailureKind.ClientNetworkError);
+        response.Exception.Should().BeSameAs(ex);
+    }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
@@ -110,11 +110,12 @@ public class UploadFailureClassifierTests
         response.Exception.Should().BeSameAs(ex);
     }
 
-    [Test]
-    public void Classify_HttpRequestExceptionWithUnexpectedEof_ShouldReturnClientNetworkError()
+    [TestCase("Received an unexpected EOF from the transport stream.")]
+    [TestCase("Received 0 bytes from the transport stream.")]
+    public void Classify_HttpRequestExceptionWithUnexpectedTransportClosureMessage_ShouldReturnClientNetworkError(string message)
     {
         using var cts = new CancellationTokenSource();
-        var ioException = new IOException("Received an unexpected EOF or 0 bytes from the transport stream.");
+        var ioException = new IOException(message);
         var ex = new HttpRequestException("The SSL connection could not be established, see inner exception.", ioException);
 
         var response = UploadFailureClassifier.Classify(ex, cts.Token);

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Strategies/UploadFailureClassifierTests.cs
@@ -70,7 +70,6 @@ public class UploadFailureClassifierTests
     public void Classify_GenericException_ShouldReturnServerError500()
     {
         using var cts = new CancellationTokenSource();
-        cts.Cancel();
         var ex = new InvalidOperationException("broken");
         
         var response = UploadFailureClassifier.Classify(ex, cts.Token);
@@ -112,6 +111,21 @@ public class UploadFailureClassifierTests
     }
 
     [Test]
+    public void Classify_HttpRequestExceptionWithUnexpectedEof_ShouldReturnClientNetworkError()
+    {
+        using var cts = new CancellationTokenSource();
+        var ioException = new IOException("Received an unexpected EOF or 0 bytes from the transport stream.");
+        var ex = new HttpRequestException("The SSL connection could not be established, see inner exception.", ioException);
+
+        var response = UploadFailureClassifier.Classify(ex, cts.Token);
+
+        response.IsSuccess.Should().BeFalse();
+        response.StatusCode.Should().Be(0);
+        response.FailureKind.Should().Be(UploadFailureKind.ClientNetworkError);
+        response.Exception.Should().BeSameAs(ex);
+    }
+
+    [Test]
     public void Classify_DirectSocketExceptionWithConnectionReset_ShouldReturnClientNetworkError()
     {
         using var cts = new CancellationTokenSource();
@@ -136,6 +150,21 @@ public class UploadFailureClassifierTests
         response.IsSuccess.Should().BeFalse();
         response.StatusCode.Should().Be(0);
         response.FailureKind.Should().Be(UploadFailureKind.ClientNetworkError);
+        response.Exception.Should().BeSameAs(ex);
+    }
+
+    [Test]
+    public void Classify_DirectSocketExceptionWithOperationAbortedAndCancelledToken_ShouldReturnClientCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var ex = new SocketException((int)SocketError.OperationAborted);
+
+        var response = UploadFailureClassifier.Classify(ex, cts.Token);
+
+        response.IsSuccess.Should().BeFalse();
+        response.StatusCode.Should().Be(0);
+        response.FailureKind.Should().Be(UploadFailureKind.ClientCancellation);
         response.Exception.Should().BeSameAs(ex);
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/AdaptiveUploadControllerTests.cs
@@ -120,6 +120,7 @@ public class AdaptiveUploadControllerTests
         _controller.CurrentParallelism.Should().Be(2);
         _controller.CurrentChunkSizeBytes.Should().BeLessThan(before);
         _controller.CurrentChunkSizeBytes.Should().BeGreaterThanOrEqualTo(64 * 1024);
+        _controller.CurrentChunkSizeBytes.Should().Be(375 * 1024);
     }
     
     [Test]
@@ -197,7 +198,7 @@ public class AdaptiveUploadControllerTests
         // Assert
         _controller.CurrentParallelism.Should().Be(2);
         _controller.CurrentChunkSizeBytes.Should().BeLessThan(500 * 1024);
-        _controller.CurrentChunkSizeBytes.Should().Be(375 * 1024);
+        _controller.CurrentChunkSizeBytes.Should().Be(250 * 1024);
     }
 
     [Test]
@@ -212,11 +213,11 @@ public class AdaptiveUploadControllerTests
 
         // Assert
         _controller.CurrentParallelism.Should().Be(2);
-        _controller.CurrentChunkSizeBytes.Should().Be(375 * 1024);
+        _controller.CurrentChunkSizeBytes.Should().Be(250 * 1024);
     }
 
     [Test]
-    public void ClientTimeouts_ReduceParallelismFirst_WhenAboveMinParallelism()
+    public void ClientTimeouts_DownscaleParallelismAndChunk_WhenAboveMinParallelism()
     {
         // Arrange
         var safety = 100;
@@ -233,8 +234,9 @@ public class AdaptiveUploadControllerTests
         FeedClientTimeouts(_controller, 2);
         
         // Assert
-        _controller.CurrentParallelism.Should().Be(beforeParallelism - 1);
-        _controller.CurrentChunkSizeBytes.Should().Be(beforeChunk);
+        _controller.CurrentParallelism.Should().Be(2);
+        _controller.CurrentParallelism.Should().BeLessThan(beforeParallelism);
+        _controller.CurrentChunkSizeBytes.Should().Be(Math.Max(64 * 1024, (int)Math.Round(beforeChunk * 0.5)));
     }
     
     [Test]

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
@@ -58,15 +58,41 @@ public class UploadAttemptTimeoutPolicyTests
         // Assert
         timeout.Should().Be(165);
     }
+
+    [Test]
+    public void ComputeTimeoutSeconds_RetryForModeratelyOversizedSlice_ShouldKeepStandardCeiling()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            2 * 1024 * 1024,
+            attempt: 4,
+            currentChunkSizeBytes: 500 * 1024);
+
+        // Assert
+        timeout.Should().Be(180);
+    }
+
+    [Test]
+    public void ComputeTimeoutSeconds_RetryForLargeStaleOversizedSlice_ShouldUseExtendedCeiling()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            2 * 1024 * 1024,
+            attempt: 4,
+            currentChunkSizeBytes: 250 * 1024);
+
+        // Assert
+        timeout.Should().Be(300);
+    }
     
     [Test]
-    public void ComputeTimeoutSeconds_ShouldNotExceedCeiling()
+    public void ComputeTimeoutSeconds_CurrentChunkSizedLargeSlice_ShouldKeepStandardCeiling()
     {
         // Act
         var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
             16 * 1024 * 1024,
             attempt: 10,
-            currentChunkSizeBytes: 64 * 1024);
+            currentChunkSizeBytes: 16 * 1024 * 1024);
         
         // Assert
         timeout.Should().Be(180);
@@ -86,7 +112,7 @@ public class UploadAttemptTimeoutPolicyTests
     }
 
     [Test]
-    public void ComputeTimeoutSeconds_WithHugeSlice_ShouldNotOverflow()
+    public void ComputeTimeoutSeconds_WithHugeStaleSlice_ShouldNotOverflow()
     {
         // Act
         var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
@@ -95,7 +121,7 @@ public class UploadAttemptTimeoutPolicyTests
             currentChunkSizeBytes: 64 * 1024);
 
         // Assert
-        timeout.Should().Be(180);
+        timeout.Should().Be(300);
     }
 
     [Test]
@@ -108,6 +134,6 @@ public class UploadAttemptTimeoutPolicyTests
             currentChunkSizeBytes: 1);
 
         // Assert
-        timeout.Should().Be(180);
+        timeout.Should().Be(300);
     }
 }

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
@@ -21,16 +21,16 @@ public class UploadAttemptTimeoutPolicyTests
     }
     
     [Test]
-    public void ComputeTimeoutSeconds_RetryForStaleLargeSlice_ShouldIncreaseBudget()
+    public void ComputeTimeoutSeconds_FirstAttemptForOversizedSlice_ShouldIncreaseBudgetImmediately()
     {
         // Act
         var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
             625 * 1024,
-            attempt: 2,
+            attempt: 1,
             currentChunkSizeBytes: 64 * 1024);
         
         // Assert
-        timeout.Should().Be(120);
+        timeout.Should().Be(180);
     }
     
     [Test]
@@ -44,6 +44,19 @@ public class UploadAttemptTimeoutPolicyTests
         
         // Assert
         timeout.Should().Be(75);
+    }
+
+    [Test]
+    public void ComputeTimeoutSeconds_RetryForOversizedSlice_ShouldKeepRetryGrowthBounded()
+    {
+        // Act
+        var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
+            2 * 1024 * 1024,
+            attempt: 2,
+            currentChunkSizeBytes: 500 * 1024);
+
+        // Assert
+        timeout.Should().Be(165);
     }
     
     [Test]
@@ -65,11 +78,11 @@ public class UploadAttemptTimeoutPolicyTests
         // Act
         var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(
             1969 * 1024,
-            attempt: 6,
+            attempt: 1,
             currentChunkSizeBytes: 500 * 1024);
 
         // Assert
-        timeout.Should().Be(150);
+        timeout.Should().Be(120);
     }
 
     [Test]

--- a/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
+++ b/tests/ByteSync.Client.UnitTests/Services/Communications/Transfers/Uploading/UploadAttemptTimeoutPolicyTests.cs
@@ -73,7 +73,7 @@ public class UploadAttemptTimeoutPolicyTests
     }
 
     [Test]
-    public void ComputeTimeoutSeconds_ForLargeStaleSliceAtLowBandwidth_ShouldAllowMoreThanTwoMinutes()
+    public void ComputeTimeoutSeconds_FirstAttemptForLargeStaleSlice_ShouldScaleWithChunkRatio()
     {
         // Act
         var timeout = UploadAttemptTimeoutPolicy.ComputeTimeoutSeconds(


### PR DESCRIPTION
## Summary
- Increase first-attempt timeout budgets for oversized stale upload slices based on the current adaptive chunk size.
- Downscale upload settings more aggressively after client timeout/network failures by returning to minimum parallelism and halving chunk size.
- Classify Windows socket operation-aborted failures as client network errors and add targeted diagnostic logging for slice/chunk ratio.

## Test plan
- dotnet test "tests/ByteSync.Client.UnitTests/ByteSync.Client.UnitTests.csproj" --filter "FullyQualifiedName~UploadAttemptTimeoutPolicyTests|FullyQualifiedName~AdaptiveUploadControllerTests|FullyQualifiedName~UploadFailureClassifierTests"
- git diff --check